### PR TITLE
[feature] #2 multi file and directory selection added

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -8,8 +8,14 @@
   <div class="top-overlay action-icon-container">
     <label class="no-margin">
       <fa-icon class="action-icon"
-               [icon]="faFileImport"></fa-icon>
-      <input type="file" accept=".htmlz,.epub" (change)="onInputChange(inputRef)" hidden #inputRef>
+               [icon]="faFileMedical"></fa-icon>
+      <input type="file" accept=".htmlz,.epub" multiple (change)="onInputChange(inputRef)" hidden #inputRef>
+    </label>
+    <label class="no-margin" *ngIf="!isMobileDevice">
+      <fa-icon class="action-icon margin-icon"
+               [icon]="faFolderPlus"></fa-icon>
+      <input type="file" webkitdirectory directory multiple (change)="onInputChange(inputDirRef)"
+        hidden #inputDirRef>
     </label>
     <fa-icon class="action-icon margin-icon"
              [icon]="faBookmark"
@@ -25,11 +31,23 @@
   Loading...
 </div>
 
+<div class="overlay-container loading-container drop-zone-container darker"
+     *ngIf="(ebookDisplayManagerService.loadingFiles$ | async)">
+  <div class="progress-container">
+    <div class="truncate">{{ebookDisplayManagerService.loadingFiles$.value?.title}}</div>
+    <div class="progress">
+      <span [style.width]="ebookDisplayManagerService.loadingFiles$.value?.progress"></span>
+    </div>
+  </div>
+</div>
+
 <ng-template #notLoadingRef>
-  <label class="overlay-container drop-zone-container label-button" *ngIf="!(visible$ | async)">
-    Drop or select a HTMLZ or EPUB file to continue
-    <input type="file" accept=".htmlz,.epub" (change)="onInputChange(inputRef)" hidden #inputRef>
+  <label class="overlay-container drop-zone-container label-button" *ngIf="!(visible$ | async)" (click)="zoneInputRef.click();"
+    (contextmenu)="$event.preventDefault();zoneInputDirRef.click();">
+    {{dropZoneLabel}}
   </label>
+  <input type="file" accept=".htmlz,.epub" multiple hidden #zoneInputRef (change)="onInputChange(zoneInputRef)">
+  <input type="file" webkitdirectory directory multiple hidden #zoneInputDirRef (change)="onInputChange(zoneInputDirRef)">
 </ng-template>
 
 <div class="dialog-overlay"

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -103,6 +103,110 @@
   display: flex;
   align-items: center;
   justify-content: center;
+
+  &.darker {
+    background-color: rgba(0, 0, 0, 0.9);
+  }
+}
+
+.progress-container {
+  width: 100vw;
+
+  > div {
+    margin: 0rem 3rem;
+
+    @media screen and (min-width: 1200px) {
+      margin: 0;
+    }
+  }
+
+  :first-child {
+    margin-bottom: 2rem;
+
+    @media screen and (min-width: 1200px) {
+      margin-bottom: 1rem;
+    }
+  }
+
+  .truncate {
+    width: calc(100vw - 6rem);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+
+    @media screen and (min-width: 1200px) {
+      width: 50vw;
+    }
+  }
+
+  .progress {
+    box-sizing: content-box;
+    height: 20px;
+    position: relative;
+    background: #555;
+    border-radius: 25px;
+    padding: 10px;
+    box-shadow: inset 0 -1px 1px rgba(255, 255, 255, 0.3);
+
+    > span {
+      display: block;
+      height: 100%;
+      border-top-right-radius: 8px;
+      border-bottom-right-radius: 8px;
+      border-top-left-radius: 20px;
+      border-bottom-left-radius: 20px;
+      background-color: rgb(43, 194, 83);
+      background-image: linear-gradient(
+        center bottom,
+        rgb(43, 194, 83) 37%,
+        rgb(84, 240, 84) 69%
+      );
+      box-shadow: inset 0 2px 9px rgba(255, 255, 255, 0.3),
+        inset 0 -2px 6px rgba(0, 0, 0, 0.4);
+      position: relative;
+      overflow: hidden;
+    }
+
+    > span::after {
+      content: "";
+      position: absolute;
+      top: 0;
+      left: 0;
+      bottom: 0;
+      right: 0;
+      background-image: linear-gradient(
+        -45deg,
+        rgba(255, 255, 255, 0.2) 25%,
+        transparent 25%,
+        transparent 50%,
+        rgba(255, 255, 255, 0.2) 50%,
+        rgba(255, 255, 255, 0.2) 75%,
+        transparent 75%,
+        transparent
+      );
+      z-index: 1;
+      background-size: 50px 50px;
+      animation: move 2s linear infinite;
+      border-top-right-radius: 8px;
+      border-bottom-right-radius: 8px;
+      border-top-left-radius: 20px;
+      border-bottom-left-radius: 20px;
+      overflow: hidden;
+    }
+  }
+
+  @keyframes move {
+    0% {
+      background-position: 0 0;
+    }
+    100% {
+      background-position: 50px 50px;
+    }
+  }
+
+  @media screen and (min-width: 1200px) {
+    width: 50vw;
+  }
 }
 
 .drop-zone-container {
@@ -116,6 +220,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  text-align: center;
 }
 
 .no-margin {

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -155,52 +155,11 @@
       border-bottom-right-radius: 8px;
       border-top-left-radius: 20px;
       border-bottom-left-radius: 20px;
-      background-color: rgb(43, 194, 83);
-      background-image: linear-gradient(
-        center bottom,
-        rgb(43, 194, 83) 37%,
-        rgb(84, 240, 84) 69%
-      );
+      background-color: #2bc253;
       box-shadow: inset 0 2px 9px rgba(255, 255, 255, 0.3),
         inset 0 -2px 6px rgba(0, 0, 0, 0.4);
       position: relative;
       overflow: hidden;
-    }
-
-    > span::after {
-      content: "";
-      position: absolute;
-      top: 0;
-      left: 0;
-      bottom: 0;
-      right: 0;
-      background-image: linear-gradient(
-        -45deg,
-        rgba(255, 255, 255, 0.2) 25%,
-        transparent 25%,
-        transparent 50%,
-        rgba(255, 255, 255, 0.2) 50%,
-        rgba(255, 255, 255, 0.2) 75%,
-        transparent 75%,
-        transparent
-      );
-      z-index: 1;
-      background-size: 50px 50px;
-      animation: move 2s linear infinite;
-      border-top-right-radius: 8px;
-      border-bottom-right-radius: 8px;
-      border-top-left-radius: 20px;
-      border-bottom-left-radius: 20px;
-      overflow: hidden;
-    }
-  }
-
-  @keyframes move {
-    0% {
-      background-position: 0 0;
-    }
-    100% {
-      background-position: 50px 50px;
     }
   }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -12,9 +12,11 @@ import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import { SwUpdate } from '@angular/service-worker';
 import { faBookmark } from '@fortawesome/free-regular-svg-icons/faBookmark';
 import { faCog } from '@fortawesome/free-solid-svg-icons/faCog';
-import { faFileImport } from '@fortawesome/free-solid-svg-icons/faFileImport';
+import { faFileMedical } from '@fortawesome/free-solid-svg-icons/faFileMedical';
+import { faFolderPlus } from '@fortawesome/free-solid-svg-icons/faFolderPlus';
 import { faSyncAlt } from '@fortawesome/free-solid-svg-icons/faSyncAlt';
 import * as parser from 'fast-xml-parser';
+import { IDBPDatabase } from 'idb';
 import { fromEvent, of } from 'rxjs';
 import { filter, map, shareReplay, switchMap, take, withLatestFrom } from 'rxjs/operators';
 import { AutoScrollerService } from './auto-scroller.service';
@@ -49,13 +51,19 @@ export class AppComponent implements OnInit {
     shareReplay(1),
   );
   loadingDb = true;
+  isMobileDevice = this.isMobile();
+  dropZoneLabel = this.isMobileDevice ?
+    'Select supported Files (HTMLZ & EPUB) to continue.' :
+    'Drop / select supported Files (HTMLZ & EPUB) or Directories (Right Click) containing them to continue.';
   dropzoneHighlight = false;
   showSettingsDialog = false;
-  faFileImport = faFileImport;
+  faFileMedical = faFileMedical;
+  faFolderPlus = faFolderPlus;
   faCog = faCog;
   faBookmark = faBookmark;
   faSyncAlt = faSyncAlt;
   isUpdateAvailable = false;
+  filePattern = /\.(?:htmlz|epub)$/;
 
   constructor(
     public autoScrollerService: AutoScrollerService,
@@ -79,7 +87,13 @@ export class AppComponent implements OnInit {
     fromEvent<DragEvent>(document.body, 'dragenter').subscribe((ev) => this.onDragEnter(ev));
     fromEvent<DragEvent>(document.body, 'dragover').subscribe((ev) => this.onDragOver(ev));
     fromEvent<DragEvent>(document.body, 'dragend').subscribe((ev) => this.onDragEnd(ev));
-    fromEvent<DragEvent>(document.body, 'drop').subscribe((ev) => this.onDrop(ev));
+    fromEvent<DragEvent>(document.body, 'drop').pipe(
+      withLatestFrom(this.ebookDisplayManagerService.loadingFiles$)).subscribe(([ev, loadingFiles$]) => {
+        ev.preventDefault();
+        if (!loadingFiles$) {
+          this.onDrop(ev);
+        }
+      });
     fromEvent<KeyboardEvent>(window, 'keydown').pipe(
       withLatestFrom(this.ebookDisplayManagerService.loadingFile$, this.visible$),
     ).subscribe(([ev, loadingFile, visible]) => {
@@ -133,11 +147,37 @@ export class AppComponent implements OnInit {
     });
   }
 
+  isMobile() {
+    let isMobileDevice = false;
+    if ('maxTouchPoints' in navigator as any) {
+      isMobileDevice = 0 < navigator.maxTouchPoints;
+    } else if ('msMaxTouchPoints' in navigator as any) {
+      isMobileDevice = 0 < navigator.msMaxTouchPoints;
+    } else {
+      const mQ = window.matchMedia?.('(pointer:coarse)');
+      if (mQ?.media === '(pointer:coarse)') {
+        isMobileDevice = !!mQ.matches;
+      } else if ('orientation' in window) {
+        isMobileDevice = true;
+      } else {
+        const UA = navigator.userAgent;
+        isMobileDevice = (
+          /\b(BlackBerry|webOS|iPhone|IEMobile)\b/i.test(UA) ||
+          /\b(Android|Windows Phone|iPad|iPod)\b/i.test(UA)
+        );
+      }
+    }
+    return isMobileDevice;
+  }
+
   onInputChange(el: HTMLInputElement) {
-    if (el.files) {
-      const file = el.files.item(0);
-      if (file) {
-        this.onFileChange(file);
+    if (el.files?.length) {
+      const validFiles = Array.from(el.files).filter((file) => this.filePattern.test(file.name));
+
+      if (validFiles.length) {
+        this.onFileChange(validFiles);
+      } else {
+        alert('Only HTMLZ and EPUB Files are supported');
       }
     }
   }
@@ -153,33 +193,66 @@ export class AppComponent implements OnInit {
   }
 
   onDrop(ev: DragEvent) {
-    ev.preventDefault();
     this.dropzoneHighlight = false;
 
-    const dropFile = (file: File) => {
-      if (/\.(?:htmlz|epub)$/.test(file.name)) {
-        this.onFileChange(file);
+    if (!ev?.dataTransfer?.items) {
+      return;
+    }
+
+    const items = [];
+
+    for (const item of ev.dataTransfer.items) {
+      if ('file' !== item.kind) {
+        continue;
+      }
+
+      items.push(item.webkitGetAsEntry());
+    }
+
+    if (items.length) {
+      this.handleDropResult(items);
+    }
+  }
+
+  async handleDropResult(items: any[]) {
+    const addFilesFromDirectory = async (entry: any, fileMap: Map<string, File>): Promise<void> => {
+      if (entry.isDirectory) {
+        const dirReader = entry.createReader();
+        const entries = await new Promise<any>((resolve) => dirReader.readEntries(resolve)).catch(() => []);
+
+        for (let index = 0, length = entries.length; index < length; index++) {
+          await addFilesFromDirectory(entries[index], fileMap).catch(() => { });
+        }
       } else {
-        alert('Only HTMLZ and EPUB files are supported');
+        const file = await new Promise<File>((resolve) => entry.file(resolve)).catch(() => { });
+
+        if (file && this.filePattern.test(file.name)) {
+          fileMap.set(file.name, file);
+        }
       }
     };
 
-    if (ev.dataTransfer) {
-      if (ev.dataTransfer.items) {
-        const item = ev.dataTransfer.items[0];
-        if (item) {
-          const file = item.getAsFile();
-          if (file) {
-            dropFile(file);
-          }
-        }
-      } else {
-        const file = ev.dataTransfer.files.item(0);
+    const files = new Map<string, File>();
+
+    for (let index = 0, length = items.length; index < length; index++) {
+      const entry = items[index];
+
+      if (entry.isDirectory) {
+        await addFilesFromDirectory(entry, files);
+      } else if (this.filePattern.test(entry.name)) {
+
+        const file = await new Promise<File>((resolve) => entry.file(resolve)).catch(() => { });
         if (file) {
-          dropFile(file);
+          files.set(file.name, file);
         }
       }
     }
+
+    if (!files.size) {
+      return alert('Only HTMLZ and EPUB Files are supported');
+    }
+
+    this.onFileChange(Array.from(files.values()));
   }
 
   onDragEnter(ev: DragEvent) {
@@ -197,14 +270,80 @@ export class AppComponent implements OnInit {
     this.dropzoneHighlight = false;
   }
 
-  private onFileChange(file: File) {
-    this.autoScrollerService.stop();
-    this.ebookDisplayManagerService.loadingFile$.next(true);
-    this.zone.runOutsideAngular(async () => {
-      try {
+  private async onFileChange(files: Array<File>) {
+    const multiFiles = 1 < files.length;
 
+    let dataId = 0;
+    let importFailures = 0;
+
+    this.autoScrollerService.stop();
+
+    if (!multiFiles) {
+      this.ebookDisplayManagerService.loadingFile$.next(true);
+    }
+
+    const db = await this.databaseService.db.catch(() => {
+      if (!multiFiles) {
+        this.ebookDisplayManagerService.loadingFile$.next(false);
+      }
+      return undefined;
+    });
+
+    if (!db) {
+      return alert('Failure accessing Database');
+    }
+
+    for (let index = 0, length = files.length; index < length; index++) {
+      const file = files[index];
+
+      if (multiFiles) {
+        this.ebookDisplayManagerService.loadingFiles$.next({
+          title: file.name,
+          progress: `${Math.round(index / length * 100)}%`
+        });
+      }
+
+      const lastDataId = await this.storeFileInDB(db, file);
+
+      if (lastDataId) {
+        dataId = lastDataId;
+      } else {
+        importFailures++;
+      }
+    }
+
+    if (importFailures) {
+      alert(`${importFailures} Import(s) failed`);
+    }
+
+    if (multiFiles) {
+      this.ebookDisplayManagerService.loadingFiles$.next(undefined);
+    }
+
+    if (!dataId) {
+      if (!multiFiles) {
+        this.ebookDisplayManagerService.loadingFile$.next(false);
+      }
+
+      return;
+    }
+
+    void db.put('lastItem', {
+      dataId,
+    }, 0).catch(() => { });
+    await this.zone.run(async () => {
+      this.ebookDisplayManagerService.loadingFile$.next(true);
+      const changedIdentifier = await this.router.navigate(['b', dataId]);
+      if (!changedIdentifier) {
+        this.ebookDisplayManagerService.revalidateFile.next();
+      }
+    }).catch(() => this.ebookDisplayManagerService.loadingFile$.next(false));
+  }
+
+  private storeFileInDB(db: IDBPDatabase<BooksDb>, file: File): Promise<number | undefined> {
+    return this.zone.runOutsideAngular(async () => {
+      try {
         const storeData = file.name.endsWith('.epub') ? await processEpub(file) : await processHtmlz(file);
-        const db = await this.databaseService.db;
         let dataId: number;
         {
           const tx = db.transaction('data', 'readwrite');
@@ -220,19 +359,11 @@ export class AppComponent implements OnInit {
             dataId = await store.add(storeData);
           }
           await tx.done;
+          return dataId;
         }
-        void db.put('lastItem', {
-          dataId,
-        }, 0);
-        await this.zone.run(async () => {
-          const changedIdentifier = await this.router.navigate(['b', dataId]);
-          if (!changedIdentifier) {
-            this.ebookDisplayManagerService.revalidateFile.next();
-          }
-        });
       } catch (ex) {
         console.error(ex);
-        alert('Import failed, please try a different file format');
+        return undefined;
       }
     });
   }

--- a/src/app/ebook-display-manager.service.ts
+++ b/src/app/ebook-display-manager.service.ts
@@ -14,12 +14,18 @@ import { skip } from 'rxjs/operators';
 // https://www.unicode.org/Public/UCD/latest/ucd/PropList.txt
 const isNotJapaneseRegex = /[^0-9A-Z○◯々-〇〻ぁ-ゖゝ-ゞァ-ヺー０-９Ａ-Ｚｦ-ﾝ\p{Ideographic}\p{Radical}\p{Unified_Ideograph}]+/gmiu;
 
+type loadingProgress = {
+  title: string;
+  progress: string;
+};
+
 @Injectable({
   providedIn: 'root'
 })
 export class EbookDisplayManagerService {
 
   loadingFile$ = new BehaviorSubject<boolean>(false);
+  loadingFiles$ = new BehaviorSubject<loadingProgress | undefined>(undefined);
   contentEl = document.createElement('div');
   contentChanged = new Subject<void>();
   revalidateFile = new Subject<void>();

--- a/src/app/reader/reader.component.ts
+++ b/src/app/reader/reader.component.ts
@@ -18,6 +18,7 @@ import { DatabaseService } from '../database.service';
 import { EbookDisplayManagerService } from '../ebook-display-manager.service';
 import { OverlayCoverManagerService } from '../overlay-cover-manager.service';
 import { ScrollInformationService } from '../scroll-information.service';
+import { buildDummyBookImage } from '../utils/html-fixer';
 import { SmoothScroll } from '../utils/smooth-scroll';
 
 const enum DeltaMode {
@@ -64,7 +65,7 @@ export class ReaderComponent implements OnInit, OnDestroy {
     this.contentElRef.nativeElement.appendChild(this.ebookDisplayManagerService.contentEl);
     this.zone.runOutsideAngular(() => {
       const wheelEventFn = SmoothScroll(document.documentElement, 4);
-      fromEvent<WheelEvent>(document, 'wheel', {passive: false})
+      fromEvent<WheelEvent>(document, 'wheel', { passive: false })
         .pipe(
           filter(() => this.ebookDisplayManagerService.allowScroll),
           takeUntil(this.destroy$),
@@ -282,7 +283,7 @@ export class ReaderComponent implements OnInit, OnDestroy {
       const url = URL.createObjectURL(value);
       urls.push(url);
       elementHtml = elementHtml.
-        replaceAll(`data:image/gif;ttu:${key};base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==`, url).
+        replaceAll(buildDummyBookImage(key), url).
         replaceAll(`ttu:${key}`, url);
     }
 

--- a/src/app/reader/reader.component.ts
+++ b/src/app/reader/reader.component.ts
@@ -276,8 +276,14 @@ export class ReaderComponent implements OnInit, OnDestroy {
     this.bookmarManagerService.identifier = data.id!;
     this.bookmarManagerService.el.hidden = true;
 
+    const urls: Array<string> = [];
+
     for (const [key, value] of Object.entries(blobs)) {
-      elementHtml = elementHtml.replaceAll(`ttu:${key}`, URL.createObjectURL(value));
+      const url = URL.createObjectURL(value);
+      urls.push(url);
+      elementHtml = elementHtml.
+        replaceAll(`data:image/gif;ttu:${key};base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==`, url).
+        replaceAll(`ttu:${key}`, url);
     }
 
     const element = document.createElement('div');
@@ -286,5 +292,10 @@ export class ReaderComponent implements OnInit, OnDestroy {
     this.scrollInformationService.initWatchParagraphs(element);
     this.ebookDisplayManagerService.updateContent(element, styleSheet);
     window.scrollTo(0, 0);
+    setTimeout(() => {
+      for (let index = 0, length = urls.length; index < length; index++) {
+        URL.revokeObjectURL(urls[index]);
+      }
+    });
   }
 }

--- a/src/app/utils/html-fixer.ts
+++ b/src/app/utils/html-fixer.ts
@@ -47,7 +47,7 @@ export function getFormattedElementHtmlz(data: Record<string, string | Blob>) {
   let html = regexResult[1];
   for (const [key, value] of Object.entries(data)) {
     if (value instanceof Blob) {
-      html = html.replaceAll(key, `data:image/gif;ttu:${key};base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==`);
+      html = html.replaceAll(key, buildDummyBookImage(key));
     }
   }
   const result = document.createElement('div');
@@ -129,7 +129,7 @@ export function getFormattedElementEpub(data: Record<string, string | Blob>, con
     const regexResult = /.*<body[^>]*>((.|\s)+)<\/body>.*/.exec(data[htmlHref] as string)!;
     let innerHtml: string = regexResult[1];
     for (const blobKey of blobsAvailable) {
-      innerHtml = innerHtml.replaceAll(relative(htmlHref, blobKey), `data:image/gif;ttu:${blobKey};base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==`);
+      innerHtml = innerHtml.replaceAll(relative(htmlHref, blobKey), buildDummyBookImage(blobKey));
     }
     const childDiv = document.createElement('div');
     childDiv.innerHTML = innerHtml;
@@ -220,4 +220,8 @@ function relative(fromPath: string, toPath: string): string {
   }
 
   return path.join(toParts.slice(fromParts.length - toParts.length).join('/'), toFilename);
+}
+
+export function buildDummyBookImage(key: string) {
+  return `data:image/gif;ttu:${key};base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==`;
 }

--- a/src/app/utils/html-fixer.ts
+++ b/src/app/utils/html-fixer.ts
@@ -27,14 +27,14 @@ function childNodesAfterContents(el: HTMLElement) {
 function clearBadImageRef(el: HTMLElement) {
   for (const tag of el.getElementsByTagName('image')) {
     const hrefAttr = tag.getAttribute('href');
-    if (hrefAttr && !hrefAttr.startsWith('ttu:')) {
+    if (hrefAttr && !(hrefAttr.startsWith('ttu:') || hrefAttr.startsWith('data:image/gif;ttu:'))) {
       tag.setAttribute('data-ttu-href', hrefAttr);
       tag.removeAttribute('href');
     }
   }
   for (const tag of el.getElementsByTagName('img')) {
     const srcAttr = tag.getAttribute('src');
-    if (srcAttr && !srcAttr.startsWith('ttu:')) {
+    if (srcAttr && !(srcAttr.startsWith('ttu:') || srcAttr.startsWith('data:image/gif;ttu:'))) {
       tag.setAttribute('data-ttu-src', srcAttr);
       tag.removeAttribute('src');
     }
@@ -47,7 +47,7 @@ export function getFormattedElementHtmlz(data: Record<string, string | Blob>) {
   let html = regexResult[1];
   for (const [key, value] of Object.entries(data)) {
     if (value instanceof Blob) {
-      html = html.replaceAll(key, `ttu:${key}`);
+      html = html.replaceAll(key, `data:image/gif;ttu:${key};base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==`);
     }
   }
   const result = document.createElement('div');
@@ -129,7 +129,7 @@ export function getFormattedElementEpub(data: Record<string, string | Blob>, con
     const regexResult = /.*<body[^>]*>((.|\s)+)<\/body>.*/.exec(data[htmlHref] as string)!;
     let innerHtml: string = regexResult[1];
     for (const blobKey of blobsAvailable) {
-      innerHtml = innerHtml.replaceAll(relative(htmlHref, blobKey), `ttu:${blobKey}`);
+      innerHtml = innerHtml.replaceAll(relative(htmlHref, blobKey), `data:image/gif;ttu:${blobKey};base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==`);
     }
     const childDiv = document.createElement('div');
     childDiv.innerHTML = innerHtml;


### PR DESCRIPTION
Adds Support for Selection of multiple Files and Directories (Desktop Only).

Open from #2:
- Are the exchanged Icons ok
- Keep Progress Color as is or replace with which Value

Latest Example Visuals: https://imgur.com/a/aRLzWkf

Should also fix #7 and unloading the overlay accordingly + an issue I saw on refold today that you are able to select other files than htmlz / epub on mobile based on your filepicker / android.

Please also not the changes in the reader component and html-fixer. Adding inplace HTML Elements still triggers Validations and therefore ttu: will throw as unknown schema for normal pages which especially for adding a directory tree is verbose. Not a direct impact for a normal User but less red is always good ;)  I therefore replaced it with a 1x1 px base64 gif while keeping the old schema during image replacement to keep backwards compability.  I also release the Blob Urls after render to free up a bit memory, Please let me know if you have concerns