### PR TITLE
Use % instead of vh to determine height

### DIFF
--- a/src/app/reader/reader.component.scss
+++ b/src/app/reader/reader.component.scss
@@ -1,8 +1,8 @@
 @mixin setHeight($heightProperty) {
-  #{$heightProperty}: 90vh;
+  #{$heightProperty}: 90%;
 
   @media screen and (min-height: 780px) {
-    #{$heightProperty}: calc(100vh - 155px);
+    #{$heightProperty}: calc(100% - 155px);
   }
 
 }


### PR DESCRIPTION
Mobile browsers (both Chrome and Firefox for Android) report the height of the entire screen as the viewport height since the browser chrome gets hidden when you scroll.

However, since you can't vertically scroll in the reader, the browser chrome remains visible and the viewport height reported is higher than what is actually visible, resulting in the top and bottom "margins" being messed up as in the picture below:
<img src="https://user-images.githubusercontent.com/5134058/127756199-f81d9cd6-fcc2-43c4-ae28-fc1f9da521b0.jpg" width="200" />

Using `%` in calculations rather than `vh` seems to be a more robust way for calculating height.