### PR TITLE
Add in button to toggle fullscreen

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -25,7 +25,7 @@
              (click)="setShowSettingsDialog(true)"></fa-icon>
   </div>
   <div class="top-overlay action-icon-container_left">
-    <fa-icon class="action-icon margin-icon" *ngIf="supportsFullScreen"
+    <fa-icon class="action-icon margin-icon" *ngIf="supportsFullscreen"
              [icon]="faExpand"
              (click)="toggleFullscreen()"></fa-icon>
   </div>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -24,6 +24,11 @@
              [icon]="faCog"
              (click)="setShowSettingsDialog(true)"></fa-icon>
   </div>
+  <div class="top-overlay action-icon-container_left">
+    <fa-icon class="action-icon margin-icon" *ngIf="supportsFullScreen"
+             [icon]="faExpand"
+             (click)="toggleFullscreen()"></fa-icon>
+  </div>
 </ng-container>
 
 <div class="overlay-container loading-container"

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -41,6 +41,16 @@
   }
 }
 
+.action-icon-container_left {
+  display: flex;
+  font-size: 16px;
+  left: 8px;
+
+  @media screen and (min-height: 900px) {
+    font-size: 24px;
+  }
+}
+
 .action-icon {
   display: block;
   cursor: pointer;

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -52,7 +52,7 @@ export class AppComponent implements OnInit {
   );
   loadingDb = true;
   isMobileDevice = this.isMobile();
-  supportsFullScreen = this.fullscreenEnabled();
+  supportsFullscreen = this.fullscreenEnabled();
   dropZoneLabel = this.isMobileDevice ?
     'Select supported files (.htmlz or .epub) to continue' :
     'Drop or select files (.htmlz or .epub) or a folder that contains those files to continue';

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -12,6 +12,7 @@ import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import { SwUpdate } from '@angular/service-worker';
 import { faBookmark } from '@fortawesome/free-regular-svg-icons/faBookmark';
 import { faCog } from '@fortawesome/free-solid-svg-icons/faCog';
+import { faExpand } from '@fortawesome/free-solid-svg-icons/faExpand';
 import { faFileMedical } from '@fortawesome/free-solid-svg-icons/faFileMedical';
 import { faFolderPlus } from '@fortawesome/free-solid-svg-icons/faFolderPlus';
 import { faSyncAlt } from '@fortawesome/free-solid-svg-icons/faSyncAlt';
@@ -51,6 +52,7 @@ export class AppComponent implements OnInit {
   );
   loadingDb = true;
   isMobileDevice = this.isMobile();
+  supportsFullScreen = this.fullscreenEnabled();
   dropZoneLabel = this.isMobileDevice ?
     'Select supported files (.htmlz or .epub) to continue' :
     'Drop or select files (.htmlz or .epub) or a folder that contains those files to continue';
@@ -61,6 +63,7 @@ export class AppComponent implements OnInit {
   faCog = faCog;
   faBookmark = faBookmark;
   faSyncAlt = faSyncAlt;
+  faExpand = faExpand;
   isUpdateAvailable = false;
   filePattern = /\.(?:htmlz|epub)$/;
 
@@ -187,6 +190,20 @@ export class AppComponent implements OnInit {
       document.body.style.overflow = 'hidden';
     } else {
       document.body.style.removeProperty('overflow');
+    }
+  }
+
+  fullscreenEnabled() {
+    return document.fullscreenEnabled ?? false;
+  }
+
+  toggleFullscreen() {
+    if (!document.fullscreenElement) {
+      document.documentElement.requestFullscreen();
+    } else {
+      if (document.exitFullscreen) {
+        document.exitFullscreen();
+      }
     }
   }
 


### PR DESCRIPTION
Mobile browsers for some reason don't let the user toggle fullscreen, so the only way for a webpage to go fullscreen on mobile is for the webpage to provide the functionality.

I've added an icon on the left side that toggles fullscreen using the Fullscreen API:
<img src="https://user-images.githubusercontent.com/5134058/127756723-0bd12d54-ec35-4e54-9874-ccabf8ea3ee1.jpg" width="200" />

The button will be hidden on browsers that don't support the Fullscreen API like Safari.

I'm happy to move the fullscreen button into Settings if we don't want it to take up space on the main screen.
