### PR TITLE
Restrict height of Settings and make scrollable for small screens

### DIFF
--- a/src/app/settings-dialog/settings-dialog.component.scss
+++ b/src/app/settings-dialog/settings-dialog.component.scss
@@ -7,6 +7,8 @@
   background-color: #ffffff;
   writing-mode: horizontal-tb;
   font-size: 16px;
+  max-height: 90%;
+  overflow-y: auto;
 }
 
 .dialog-padding {


### PR DESCRIPTION
The settings dialog is not very usable if the page does not have enough vertical height.

This change restricts the maximum vertical height of the dialog and makes the dialog scrollable when needed.