### PR TITLE
Refactor to simplify creation of local storage backed BehaviorSubjects.

### DIFF
--- a/src/app/ebook-display-manager.service.ts
+++ b/src/app/ebook-display-manager.service.ts
@@ -9,7 +9,9 @@
 
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Subject } from 'rxjs';
-import { skip } from 'rxjs/operators';
+import { 
+  createBooleanLocalStorageBehaviorSubject,
+  createNumberLocalStorageBehaviorSubject } from './utils/local-storage-utils';
 
 // https://www.unicode.org/Public/UCD/latest/ucd/PropList.txt
 const isNotJapaneseRegex = /[^0-9A-Z○◯々-〇〻ぁ-ゖゝ-ゞァ-ヺー０-９Ａ-Ｚｦ-ﾝ\p{Ideographic}\p{Radical}\p{Unified_Ideograph}]+/gmiu;
@@ -41,50 +43,9 @@ export class EbookDisplayManagerService {
   constructor() {
     document.head.insertBefore(this.bookStyle, document.head.firstChild);
 
-    const storedFontSize = localStorage.getItem('fontSize');
-    let defaultFontSize: number;
-    if (storedFontSize) {
-      defaultFontSize = +storedFontSize;
-    } else {
-      defaultFontSize = 20;
-    }
-    this.fontSize$ = new BehaviorSubject(defaultFontSize);
-
-    this.fontSize$.pipe(
-      skip(1),
-    ).subscribe((fontSize) => {
-      localStorage.setItem('fontSize', `${fontSize}`);
-    });
-
-    const storedHideSpoilerImage = localStorage.getItem('hideSpoilerImage');
-    let defaultHideSpoilerImage: boolean;
-    if (storedHideSpoilerImage) {
-      defaultHideSpoilerImage = !!(+storedHideSpoilerImage);
-    } else {
-      defaultHideSpoilerImage = true;
-    }
-    this.hideSpoilerImage$ = new BehaviorSubject(defaultHideSpoilerImage);
-
-    this.hideSpoilerImage$.pipe(
-      skip(1),
-    ).subscribe((hideSpoilerImage) => {
-      localStorage.setItem('hideSpoilerImage', hideSpoilerImage ? '1' : '0');
-    });
-
-    const storedHideFurigana = localStorage.getItem('hideFurigana');
-    let defaultHideFurigana: boolean;
-    if (storedHideFurigana) {
-      defaultHideFurigana = !!(+storedHideFurigana);
-    } else {
-      defaultHideFurigana = false;
-    }
-    this.hideFurigana$ = new BehaviorSubject(defaultHideFurigana);
-
-    this.hideFurigana$.pipe(
-      skip(1),
-    ).subscribe((hideFurigana) => {
-      localStorage.setItem('hideFurigana', hideFurigana ? '1' : '0');
-    });
+    this.fontSize$ = createNumberLocalStorageBehaviorSubject('fontSize', 20);
+    this.hideSpoilerImage$ = createBooleanLocalStorageBehaviorSubject('hideSpoilerImage', true);
+    this.hideFurigana$ = createBooleanLocalStorageBehaviorSubject('hideFurigana', false);
   }
 
   updateContent(el: HTMLElement, styleString: string) {

--- a/src/app/utils/local-storage-utils.ts
+++ b/src/app/utils/local-storage-utils.ts
@@ -11,33 +11,33 @@ import { BehaviorSubject } from "rxjs";
 import { skip } from "rxjs/operators";
 
 export function getStoredBooleanOrDefault(key: string, defaultVal: boolean): boolean {
-    const storedVal = localStorage.getItem(key);
-    return storedVal != null ? !!(+storedVal) : defaultVal;
+  const storedVal = localStorage.getItem(key);
+  return storedVal != null ? !!(+storedVal) : defaultVal;
 }
 
 export function getStoredNumberOrDefault(key: string, defaultVal: number): number {
-    const storedVal = localStorage.getItem(key);
-    return storedVal != null ? +storedVal : defaultVal;
+  const storedVal = localStorage.getItem(key);
+  return storedVal != null ? +storedVal : defaultVal;
 }
 
 export function createBooleanLocalStorageBehaviorSubject(key: string, defaultVal: boolean): BehaviorSubject<boolean> {
-    const initVal = getStoredBooleanOrDefault(key, defaultVal);
-    const behaviorSubject = new BehaviorSubject<boolean>(initVal);
-    behaviorSubject.pipe(
-        skip(1),
-    ).subscribe((updatedVal) => {
-        localStorage.setItem(key, updatedVal ? '1' : '0');
-    });
-    return behaviorSubject;
+  const initVal = getStoredBooleanOrDefault(key, defaultVal);
+  const behaviorSubject = new BehaviorSubject<boolean>(initVal);
+  behaviorSubject.pipe(
+    skip(1),
+  ).subscribe((updatedVal) => {
+    localStorage.setItem(key, updatedVal ? '1' : '0');
+  });
+  return behaviorSubject;
 }
 
 export function createNumberLocalStorageBehaviorSubject(key: string, defaultVal: number): BehaviorSubject<number> {
-    const initVal = getStoredNumberOrDefault(key, defaultVal);
-    const behaviorSubject = new BehaviorSubject<number>(initVal);
-    behaviorSubject.pipe(
-        skip(1),
-    ).subscribe((updatedVal) => {
-        localStorage.setItem(key, `${updatedVal}`);
-    });
-    return behaviorSubject;
+  const initVal = getStoredNumberOrDefault(key, defaultVal);
+  const behaviorSubject = new BehaviorSubject<number>(initVal);
+  behaviorSubject.pipe(
+    skip(1),
+  ).subscribe((updatedVal) => {
+    localStorage.setItem(key, `${updatedVal}`);
+  });
+  return behaviorSubject;
 }

--- a/src/app/utils/local-storage-utils.ts
+++ b/src/app/utils/local-storage-utils.ts
@@ -1,0 +1,43 @@
+/**
+ * @licence
+ * Copyright (c) 2021, ッツ Reader Authors
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { BehaviorSubject } from "rxjs";
+import { skip } from "rxjs/operators";
+
+export function getStoredBooleanOrDefault(key: string, defaultVal: boolean): boolean {
+    const storedVal = localStorage.getItem(key);
+    return storedVal != null ? !!(+storedVal) : defaultVal;
+}
+
+export function getStoredNumberOrDefault(key: string, defaultVal: number): number {
+    const storedVal = localStorage.getItem(key);
+    return storedVal != null ? +storedVal : defaultVal;
+}
+
+export function createBooleanLocalStorageBehaviorSubject(key: string, defaultVal: boolean): BehaviorSubject<boolean> {
+    const initVal = getStoredBooleanOrDefault(key, defaultVal);
+    const behaviorSubject = new BehaviorSubject<boolean>(initVal);
+    behaviorSubject.pipe(
+        skip(1),
+    ).subscribe((updatedVal) => {
+        localStorage.setItem(key, updatedVal ? '1' : '0');
+    });
+    return behaviorSubject;
+}
+
+export function createNumberLocalStorageBehaviorSubject(key: string, defaultVal: number): BehaviorSubject<number> {
+    const initVal = getStoredNumberOrDefault(key, defaultVal);
+    const behaviorSubject = new BehaviorSubject<number>(initVal);
+    behaviorSubject.pipe(
+        skip(1),
+    ).subscribe((updatedVal) => {
+        localStorage.setItem(key, `${updatedVal}`);
+    });
+    return behaviorSubject;
+}


### PR DESCRIPTION
Extracted out common code for creating BehaviorSubjects that are backed by LocalStorage into utility functions.

This is in preparation for a change that I will be making to add in tooltips + a setting to toggle them.