### PR TITLE
Add in tooltips for icons

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -7,25 +7,30 @@
 
   <div class="top-overlay action-icon-container">
     <label class="no-margin">
-      <fa-icon class="action-icon"
+      <fa-icon class="action-icon" data-tooltip="Import File"
+               [ngClass]="{'tooltip bottom-center': uiSettingsService.showTooltips$ | async}"
                [icon]="faFileMedical"></fa-icon>
       <input type="file" accept=".htmlz,.epub" multiple (change)="onInputChange(inputRef)" hidden #inputRef>
     </label>
     <label class="no-margin" *ngIf="!isMobileDevice">
-      <fa-icon class="action-icon margin-icon"
+      <fa-icon class="action-icon margin-icon" data-tooltip="Import Folder"
+               [ngClass]="{'tooltip bottom-center': uiSettingsService.showTooltips$ | async}"
                [icon]="faFolderPlus"></fa-icon>
       <input type="file" webkitdirectory directory multiple (change)="onInputChange(inputDirRef)"
         hidden #inputDirRef>
     </label>
-    <fa-icon class="action-icon margin-icon"
+    <fa-icon class="action-icon margin-icon" data-tooltip="Bookmark"
+             [ngClass]="{'tooltip bottom-center': uiSettingsService.showTooltips$ | async}"
              [icon]="faBookmark"
              (click)="bookmarManagerService.saveScrollPosition()"></fa-icon>
-    <fa-icon class="action-icon margin-icon"
+    <fa-icon class="action-icon margin-icon" data-tooltip="Settings"
+             [ngClass]="{'tooltip bottom-right': uiSettingsService.showTooltips$ | async}"
              [icon]="faCog"
              (click)="setShowSettingsDialog(true)"></fa-icon>
   </div>
   <div class="top-overlay action-icon-container--left">
-    <fa-icon class="action-icon margin-icon"
+    <fa-icon class="action-icon margin-icon" data-tooltip="Toggle Fullscreen"
+             [ngClass]="{'tooltip bottom-left': uiSettingsService.showTooltips$ | async}"
              *ngIf="!(minimalUi$ | async) && supportsFullscreen && !autoScrollerService.activated"
              [icon]="faExpand"
              (click)="toggleFullscreen()"></fa-icon>

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -7,29 +7,29 @@
 
   <div class="top-overlay action-icon-container">
     <label class="no-margin">
-      <fa-icon class="action-icon" data-tooltip="Import File"
+      <fa-icon class="action-icon" data-ttu-tooltip="Import File"
                [ngClass]="{'tooltip bottom-center': uiSettingsService.showTooltips$ | async}"
                [icon]="faFileMedical"></fa-icon>
       <input type="file" accept=".htmlz,.epub" multiple (change)="onInputChange(inputRef)" hidden #inputRef>
     </label>
     <label class="no-margin" *ngIf="!isMobileDevice">
-      <fa-icon class="action-icon margin-icon" data-tooltip="Import Folder"
+      <fa-icon class="action-icon margin-icon" data-ttu-tooltip="Import Folder"
                [ngClass]="{'tooltip bottom-center': uiSettingsService.showTooltips$ | async}"
                [icon]="faFolderPlus"></fa-icon>
       <input type="file" webkitdirectory directory multiple (change)="onInputChange(inputDirRef)"
         hidden #inputDirRef>
     </label>
-    <fa-icon class="action-icon margin-icon" data-tooltip="Bookmark"
+    <fa-icon class="action-icon margin-icon" data-ttu-tooltip="Bookmark"
              [ngClass]="{'tooltip bottom-center': uiSettingsService.showTooltips$ | async}"
              [icon]="faBookmark"
              (click)="bookmarManagerService.saveScrollPosition()"></fa-icon>
-    <fa-icon class="action-icon margin-icon" data-tooltip="Settings"
+    <fa-icon class="action-icon margin-icon" data-ttu-tooltip="Settings"
              [ngClass]="{'tooltip bottom-right': uiSettingsService.showTooltips$ | async}"
              [icon]="faCog"
              (click)="setShowSettingsDialog(true)"></fa-icon>
   </div>
   <div class="top-overlay action-icon-container--left">
-    <fa-icon class="action-icon margin-icon" data-tooltip="Toggle Fullscreen"
+    <fa-icon class="action-icon margin-icon" data-ttu-tooltip="Toggle Fullscreen"
              [ngClass]="{'tooltip bottom-left': uiSettingsService.showTooltips$ | async}"
              *ngIf="!(minimalUi$ | async) && supportsFullscreen && !autoScrollerService.activated"
              [icon]="faExpand"

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -206,3 +206,41 @@
 .update-ready-icon {
   left: 8px;
 }
+
+.tooltip {
+  position: relative;
+
+  &:before {
+    content: attr(data-tooltip);
+    position: absolute;
+
+    max-width: 130px;
+    padding :10px;
+    border-radius: 10px;
+    background:#000;
+    color: #fff;
+    text-align: center;
+
+    display: none;
+  }
+
+  &:hover:before {
+    display: block;
+  }
+
+  &.bottom-left:before {
+    top: 100%;
+    left: 0%;
+  }
+
+  &.bottom-center:before {
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  &.bottom-right:before {
+    top: 100%;
+    right: 0%;
+  }
+}

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -211,7 +211,7 @@
   position: relative;
 
   &:before {
-    content: attr(data-tooltip);
+    content: attr(data-ttu-tooltip);
     position: absolute;
 
     max-width: 130px;

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -217,7 +217,7 @@
     max-width: 130px;
     padding :10px;
     border-radius: 10px;
-    background:#000;
+    background: #000;
     color: #fff;
     text-align: center;
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -26,6 +26,7 @@ import { BooksDb, DatabaseService } from './database.service';
 import { EbookDisplayManagerService } from './ebook-display-manager.service';
 import { ScrollInformationService } from './scroll-information.service';
 import { ThemeManagerService } from './theme-manager.service';
+import { UiSettingsService } from './ui-settings-service';
 import parseCss from './utils/css-parser';
 import stringifyCss from './utils/css-stringify';
 import { EpubExtractor, HtmlzExtractor } from './utils/extractor';
@@ -75,6 +76,7 @@ export class AppComponent implements OnInit {
     public autoScrollerService: AutoScrollerService,
     public bookmarManagerService: BookmarkManagerService,
     public ebookDisplayManagerService: EbookDisplayManagerService,
+    public uiSettingsService: UiSettingsService,
     private scrollInformationService: ScrollInformationService,
     private themeManagerService: ThemeManagerService,
     private databaseService: DatabaseService,

--- a/src/app/settings-dialog/settings-dialog.component.html
+++ b/src/app/settings-dialog/settings-dialog.component.html
@@ -35,6 +35,12 @@
           (click)="onHideFuriganaClick()"
           [class.active]="ebookDisplayManagerService.hideFurigana$ | async">ON</span>
     </div>
+    <div class="item-header">Show Tooltips</div>
+      <div class="button-row">
+      <span class="label-button button-styling clickable-button"
+            (click)="onShowTooltipsClick()"
+            [class.active]="uiSettingsService.showTooltips$ | async">ON</span>
+    </div>
   </div>
   <footer class="dialog-footer">
     <button (click)="closeClick.emit()" class="button label-button button-styling" type="button">Close</button>

--- a/src/app/settings-dialog/settings-dialog.component.ts
+++ b/src/app/settings-dialog/settings-dialog.component.ts
@@ -12,6 +12,7 @@ import { faMinus } from '@fortawesome/free-solid-svg-icons/faMinus';
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
 import { EbookDisplayManagerService } from '../ebook-display-manager.service';
 import { ThemeManagerService } from '../theme-manager.service';
+import { UiSettingsService } from '../ui-settings-service';
 
 
 @Component({
@@ -29,6 +30,7 @@ export class SettingsDialogComponent implements OnInit {
   constructor(
     public themeManagerService: ThemeManagerService,
     public ebookDisplayManagerService: EbookDisplayManagerService,
+    public uiSettingsService: UiSettingsService,
     public cdr: ChangeDetectorRef,
   ) { }
 
@@ -52,6 +54,11 @@ export class SettingsDialogComponent implements OnInit {
 
   onHideFuriganaClick() {
     this.ebookDisplayManagerService.hideFurigana$.next(!this.ebookDisplayManagerService.hideFurigana$.value);
+    this.cdr.markForCheck();
+  }
+
+  onShowTooltipsClick() {
+    this.uiSettingsService.showTooltips$.next(!this.uiSettingsService.showTooltips$.value);
     this.cdr.markForCheck();
   }
 }

--- a/src/app/ui-settings-service.ts
+++ b/src/app/ui-settings-service.ts
@@ -1,0 +1,23 @@
+/**
+ * @licence
+ * Copyright (c) 2021, ッツ Reader Authors
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { createBooleanLocalStorageBehaviorSubject } from './utils/local-storage-utils';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class UiSettingsService {
+  showTooltips$: BehaviorSubject<boolean>;
+
+  constructor() {
+    this.showTooltips$ = createBooleanLocalStorageBehaviorSubject('showTooltips', true);
+  }
+}


### PR DESCRIPTION
As mentioned in #11, as we add more features/icons to the reader, having some tooltips will help users figure out what things do in the reader.

Changes in this PR:
- Add in simple CSS-based tooltips that shows up when you hover or touch an icon
- Add in an option to toggle tooltips in settings in case they get annoying
- Create a new `UiSettingsService` which will handle storing the tooltip setting as well as future UI related settings

Demo available at: https://yellowjello.github.io/read/