### PR TITLE
minimze element breaks for paginated view

### DIFF
--- a/apps/web/src/lib/components/book-reader/book-reader-paginated/book-reader-paginated.svelte
+++ b/apps/web/src/lib/components/book-reader/book-reader-paginated/book-reader-paginated.svelte
@@ -369,6 +369,11 @@
       max-width: var(--book-content-child-width, 100vw);
       max-height: var(--book-content-child-height, 100vh);
     }
+    :global(p) {
+      -webkit-column-break-inside: avoid;
+      page-break-inside: avoid;
+      break-inside: avoid;
+    }
   }
 
   .book-content--writing-vertical-rl {


### PR DESCRIPTION
I noticed there are quite a few breaks inside elements across a page (especially on mobile)

This attribute will not fix all but should lower down the amount of such occurences