### PR TITLE
feat: toggle furigana display and settings view rearrangement

### DIFF
--- a/apps/web/src/lib/components/book-reader/book-reader-continuous/book-reader-continuous.svelte
+++ b/apps/web/src/lib/components/book-reader/book-reader-continuous/book-reader-continuous.svelte
@@ -274,6 +274,7 @@
   class:book-content--hide-spoiler-image={hideSpoilerImage}
   class:book-content--furigana-style-partial={furiganaStyle === FuriganaStyle.Partial}
   class:book-content--furigana-style-full={furiganaStyle === FuriganaStyle.Full}
+  class:book-content--furigana-style-toggle={furiganaStyle === FuriganaStyle.Toggle}
   class="book-content m-auto"
 >
   <HtmlRenderer html={htmlContent} on:load={onHtmlLoad} />

--- a/apps/web/src/lib/components/book-reader/book-reader-paginated/book-reader-paginated.svelte
+++ b/apps/web/src/lib/components/book-reader/book-reader-paginated/book-reader-paginated.svelte
@@ -323,6 +323,7 @@
   class:book-content--hide-spoiler-image={hideSpoilerImage}
   class:book-content--furigana-style-partial={furiganaStyle === FuriganaStyle.Partial}
   class:book-content--furigana-style-full={furiganaStyle === FuriganaStyle.Full}
+  class:book-content--furigana-style-toggle={furiganaStyle === FuriganaStyle.Toggle}
   class="book-content m-auto"
   use:swipe={{ timeframe: 500, minSwipeDistance: 10, touchAction: 'pan-y' }}
   on:swipe={onSwipe}

--- a/apps/web/src/lib/components/book-reader/book-reader.svelte
+++ b/apps/web/src/lib/components/book-reader/book-reader.svelte
@@ -105,7 +105,7 @@
 
   const reactiveElements$ = iffBrowser(() => of(document)).pipe(
     mergeMap((document) => {
-      const reactiveElementsFn = reactiveElements(document);
+      const reactiveElementsFn = reactiveElements(document, furiganaStyle);
       return contentEl$.pipe(mergeMap((contentEl) => reactiveElementsFn(contentEl)));
     }),
     reduceToEmptyString()

--- a/apps/web/src/lib/components/book-reader/reactive-elements.ts
+++ b/apps/web/src/lib/components/book-reader/reactive-elements.ts
@@ -6,14 +6,16 @@
 
 import { fromEvent, merge, take, tap } from 'rxjs';
 
-export function reactiveElements(document: Document) {
+import { FuriganaStyle } from '../../data/furigana-style';
+
+export function reactiveElements(document: Document, furiganaStyle: FuriganaStyle) {
   const anchorTagDocumentListener = anchorTagListener(document);
   const spoilerImageDocumentListener = spoilerImageListener(document);
 
   return (contentEl: HTMLElement) =>
     merge(
       anchorTagDocumentListener(contentEl),
-      rubyTagListener(contentEl),
+      rubyTagListener(contentEl, furiganaStyle),
       spoilerImageDocumentListener(contentEl)
     );
 }
@@ -40,13 +42,22 @@ function anchorTagListener(document: Document) {
   };
 }
 
-function rubyTagListener(contentEl: HTMLElement) {
+function rubyTagListener(contentEl: HTMLElement, furiganaStyle: FuriganaStyle) {
+  const isToggle = furiganaStyle === FuriganaStyle.Toggle;
   const rubyTags = Array.from(contentEl.getElementsByTagName('ruby'));
   const obs$ = rubyTags.map((el) =>
-    fromClickEvent(el).pipe(
-      take(1),
-      tap(() => el.classList.add('reveal-rt'))
-    )
+    isToggle
+      ? fromClickEvent(el).pipe(
+          tap(() => {
+            el.classList.toggle('reveal-rt');
+          })
+        )
+      : fromClickEvent(el).pipe(
+          take(1),
+          tap(() => {
+            el.classList.add('reveal-rt');
+          })
+        )
   );
   return merge(...obs$);
 }

--- a/apps/web/src/lib/components/book-reader/styles.scss
+++ b/apps/web/src/lib/components/book-reader/styles.scss
@@ -52,8 +52,10 @@
   }
 }
 
-.book-content--hide-furigana.book-content--furigana-style-full {
+.book-content--hide-furigana.book-content--furigana-style-full,
+.book-content--hide-furigana.book-content--furigana-style-toggle {
   :global(ruby) {
+    cursor: pointer;
     text-shadow: var(--book-content-hint-furigana-shadow-color) 1px 0 10px;
 
     :global(rt) {
@@ -74,6 +76,18 @@
 
     :global(rt) {
       visibility: visible;
+    }
+  }
+}
+
+.book-content--hide-furigana.book-content--furigana-style-toggle {
+  :global(ruby) {
+    @media (hover: hover) {
+      &:not(.reveal-rt):hover {
+        :global(rt) {
+          visibility: hidden;
+        }
+      }
     }
   }
 }

--- a/apps/web/src/lib/components/form-field/form-field.svelte
+++ b/apps/web/src/lib/components/form-field/form-field.svelte
@@ -4,10 +4,12 @@
 </script>
 
 <!-- svelte-ignore a11y-label-has-associated-control -->
-<label class="block">
-  <span class="text-lg">{title}</span>
-  <slot />
-</label>
-{#if marginBottom}
-  <div class="mb-4" />
-{/if}
+<div>
+  <label class="block">
+    <span class="text-lg">{title}</span>
+    <slot />
+  </label>
+  {#if marginBottom}
+    <div class="mb-4" />
+  {/if}
+</div>

--- a/apps/web/src/lib/components/settings/settings-content.svelte
+++ b/apps/web/src/lib/components/settings/settings-content.svelte
@@ -68,6 +68,10 @@
     {
       id: FuriganaStyle.Full,
       text: 'Full'
+    },
+    {
+      id: FuriganaStyle.Toggle,
+      text: 'Toggle'
     }
   ];
 
@@ -100,7 +104,7 @@
   <ButtonToggleGroup options={optionsForTheme} bind:selectedOptionId={selectedTheme} />
 </SettingsItemGroup>
 
-<SettingsItemGroup title="Font settings">
+<SettingsItemGroup title="Font settings" asGrid>
   <FormField title="Font size">
     <input type="number" class={inputClasses} step="1" min="1" bind:value={fontSize} />
   </FormField>
@@ -122,57 +126,54 @@
   </FormField>
 </SettingsItemGroup>
 
-<SettingsItemGroup title="Blur image">
-  <ButtonToggleGroup options={optionsForToggle} bind:selectedOptionId={blurImage} />
-</SettingsItemGroup>
-
-<SettingsItemGroup title="Hide furigana">
-  <ButtonToggleGroup options={optionsForToggle} bind:selectedOptionId={hideFurigana} />
-</SettingsItemGroup>
-
-<SettingsItemGroup title="Hide furigana style">
-  <ButtonToggleGroup options={optionsForFuriganaStyle} bind:selectedOptionId={furiganaStyle} />
-</SettingsItemGroup>
-
-<SettingsItemGroup title="Writing mode">
-  <ButtonToggleGroup options={optionsForWritingMode} bind:selectedOptionId={writingMode} />
-</SettingsItemGroup>
-
-<SettingsItemGroup title="View mode">
-  <ButtonToggleGroup options={optionsForViewMode} bind:selectedOptionId={viewMode} />
-</SettingsItemGroup>
-
-{#if viewMode === ViewMode.Continuous}
-  <SettingsItemGroup title="Reader size">
-    <FormField title={verticalMode ? 'Max height' : 'Max width'}>
-      <input
-        type="number"
-        class={inputClasses}
-        step="1"
-        min="0"
-        bind:value={secondDimensionMaxValue}
-      />
-    </FormField>
-
-    <FormField
-      title={verticalMode ? 'Left/right margin' : 'Top/bottom margin'}
-      marginBottom={false}
-    >
-      <input
-        type="number"
-        class={inputClasses}
-        step="1"
-        min="0"
-        bind:value={firstDimensionMargin}
-      />
-    </FormField>
+<div class="grid grid-cols-1 sm:grid-cols-2 md:gap-y-2 lg:grid-cols-3 lg:gap-x-8 lg:gap-y-10">
+  <SettingsItemGroup title="View mode">
+    <ButtonToggleGroup options={optionsForViewMode} bind:selectedOptionId={viewMode} />
   </SettingsItemGroup>
-
-  <SettingsItemGroup title="Auto position on resize">
-    <ButtonToggleGroup options={optionsForToggle} bind:selectedOptionId={autoPositionOnResize} />
+  <SettingsItemGroup title="Writing mode">
+    <ButtonToggleGroup options={optionsForWritingMode} bind:selectedOptionId={writingMode} />
   </SettingsItemGroup>
-{/if}
+  <SettingsItemGroup title="Blur image">
+    <ButtonToggleGroup options={optionsForToggle} bind:selectedOptionId={blurImage} />
+  </SettingsItemGroup>
+  <SettingsItemGroup title="Hide furigana">
+    <ButtonToggleGroup options={optionsForToggle} bind:selectedOptionId={hideFurigana} />
+  </SettingsItemGroup>
+  <SettingsItemGroup title="Hide furigana style">
+    <ButtonToggleGroup options={optionsForFuriganaStyle} bind:selectedOptionId={furiganaStyle} />
+  </SettingsItemGroup>
+  <SettingsItemGroup title="Persistent storage">
+    <ButtonToggleGroup options={optionsForToggle} bind:selectedOptionId={persistentStorage} />
+  </SettingsItemGroup>
+  {#if viewMode === ViewMode.Continuous}
+    <SettingsItemGroup title="Auto position on resize">
+      <ButtonToggleGroup options={optionsForToggle} bind:selectedOptionId={autoPositionOnResize} />
+    </SettingsItemGroup>
+    <div class="lg:col-span-2">
+      <SettingsItemGroup title="Reader size" asGrid columns={2}>
+        <FormField title={verticalMode ? 'Max height' : 'Max width'}>
+          <input
+            type="number"
+            class={inputClasses}
+            step="1"
+            min="0"
+            bind:value={secondDimensionMaxValue}
+          />
+        </FormField>
 
-<SettingsItemGroup title="Persistent storage">
-  <ButtonToggleGroup options={optionsForToggle} bind:selectedOptionId={persistentStorage} />
-</SettingsItemGroup>
+        <FormField
+          title={verticalMode ? 'Left/right margin' : 'Top/bottom margin'}
+          marginBottom={false}
+        >
+          <input
+            type="number"
+            class={inputClasses}
+            step="1"
+            min="0"
+            bind:value={firstDimensionMargin}
+          />
+        </FormField>
+      </SettingsItemGroup>
+    </div>
+  {/if}
+</div>

--- a/apps/web/src/lib/components/settings/settings-item-group.svelte
+++ b/apps/web/src/lib/components/settings/settings-item-group.svelte
@@ -1,10 +1,16 @@
 <script type="ts">
   export let title: string;
+  export let asGrid = false;
+  export let columns = 3;
+
+  $: containerClasses = asGrid ? `grid md:grid-cols-${columns} gap-x-8` : '';
 </script>
 
 <section class="pb-8">
   <h2 class="mb-2 text-xl font-medium capitalize">
     {title}
   </h2>
-  <slot />
+  <div class={containerClasses}>
+    <slot />
+  </div>
 </section>

--- a/apps/web/src/lib/data/furigana-style.ts
+++ b/apps/web/src/lib/data/furigana-style.ts
@@ -6,5 +6,6 @@
 
 export enum FuriganaStyle {
   Partial = 'partial',
-  Full = 'full'
+  Full = 'full',
+  Toggle = 'toggle'
 }

--- a/apps/web/src/lib/data/theme-option.ts
+++ b/apps/web/src/lib/data/theme-option.ts
@@ -105,7 +105,7 @@ const darkTheme = updateHintFuriganaFontColor({
     r: 240,
     g: 240,
     b: 241,
-    a: 0.7
+    a: 0.3
   },
   tooltipTextFontColor: {
     r: 0xff,

--- a/apps/web/src/routes/settings/index.svelte
+++ b/apps/web/src/routes/settings/index.svelte
@@ -67,7 +67,7 @@
 </div>
 
 <div class="{pxScreen} h-full pt-16 xl:pt-14">
-  <div class="max-w-md">
+  <div class="max-w-5xl">
     <SettingsContent
       bind:selectedTheme={$theme$}
       bind:fontSize={$fontSize$}

--- a/apps/web/tailwind.config.cjs
+++ b/apps/web/tailwind.config.cjs
@@ -24,6 +24,12 @@ const config = {
     plugin(({ addUtilities }) => {
       addUtilities(require('./tailwindcss/material-elevation.cjs'));
     })
+  ],
+  safelist: [
+    {
+      pattern: /grid-cols-(2|3)/,
+      variants: ['md']
+    }
   ]
 };
 


### PR DESCRIPTION
Includes following changes

- Responsive Column Layout for settings view (1-3 columns) and order a bit rearranged
- I read often about people disliking the glow effect on hidden furigana for dark themes - i aligned the opacity to the light themes and add a pointer cursor as additional aid
- New Option Value for Furigana style which is a on click toggle instead of hover (should solve #20 i guess)

deployed on a demo branch : https://renji-xd.github.io/ebook-reader