### PR TITLE
fix: write back default value for storage

### DIFF
--- a/apps/web/src/lib/data/internal/writable-storage-subject.ts
+++ b/apps/web/src/lib/data/internal/writable-storage-subject.ts
@@ -5,8 +5,8 @@
  */
 
 import { skip } from 'rxjs';
-import { writableSubject } from '$lib/functions/svelte/store';
 import type { localStorage } from '../window/local-storage';
+import { writableSubject } from '$lib/functions/svelte/store';
 
 type Storage = typeof localStorage;
 
@@ -19,7 +19,7 @@ export function writableStorageSubject<T>(
     const initValue = getStoredOrDefault(storage)(key, defaultValue, mapFromString);
     const subject = writableSubject(initValue);
     subject.pipe(skip(1)).subscribe((updatedValue) => {
-      storage.setItem(key, mapToString(updatedValue));
+      storage.setItem(key, mapToString(updatedValue ?? defaultValue));
     });
     return subject;
   };


### PR DESCRIPTION
There are no real validations on the settings which allows e. g. to have null for number settings.

Some code handles it, some not - e. g. the continuous scrolling for page up/down is breaking when a page is reloaded with null as value for the firstDimensionMargin.

PR writes back the defaultvalue in the writeable storage in case of undefined values