### PR TITLE
fix: include configured margin for bookmark and character stats

### DIFF
--- a/apps/web/src/lib/components/book-reader/book-reader-continuous/book-reader-continuous.svelte
+++ b/apps/web/src/lib/components/book-reader/book-reader-continuous/book-reader-continuous.svelte
@@ -148,7 +148,9 @@
   $: {
     if (browser && calculator) {
       bookmarkManagerConcrete =
-        browser && calculator && new BookmarkManagerContinuous(calculator, window);
+        browser &&
+        calculator &&
+        new BookmarkManagerContinuous(calculator, window, firstDimensionMargin || 0);
       bookmarkManager = bookmarkManagerConcrete;
     }
   }
@@ -299,12 +301,12 @@
 
 {#if firstDimensionMargin}
   <div
-    class="fixed"
+    class="fixed z-[5]"
     style:background-color={backgroundColor}
     style="{fullLengthDimension}: 100%; {modifyingDimension}: {firstDimensionMargin}px; {boundSide[0]}: 0"
   />
   <div
-    class="fixed"
+    class="fixed z-[5]"
     style:background-color={backgroundColor}
     style="{fullLengthDimension}: 100%; {modifyingDimension}: {firstDimensionMargin}px; {boundSide[1]}: 0"
   />
@@ -313,13 +315,15 @@
 {#if bookmarkPos}
   {#if verticalMode}
     <div
+      style:height={`${maxHeight || height}px`}
       style:right={bookmarkPos.right}
-      class="pointer-events-none absolute inset-y-0 w-12 bg-yellow-600 bg-opacity-10"
+      class="pointer-events-none absolute inset-y-0 m-auto w-12 bg-yellow-600 bg-opacity-10"
     />
   {:else}
     <div
+      style:width={`${secondDimensionMaxValue || width}px`}
       style:top={bookmarkPos.top}
-      class="absolute inset-x-0 h-12 bg-yellow-600 bg-opacity-10 pointer-events-none"
+      class="absolute inset-x-0 h-12 bg-yellow-600 bg-opacity-10 pointer-events-none m-auto"
     />
   {/if}
 {/if}

--- a/apps/web/src/lib/components/book-reader/book-reader-continuous/bookmark-manager-continuous.ts
+++ b/apps/web/src/lib/components/book-reader/book-reader-continuous/bookmark-manager-continuous.ts
@@ -4,19 +4,23 @@
  * All rights reserved.
  */
 
-import type { BooksDbBookmarkData } from '$lib/data/database/books-db/versions/books-db';
-import { formatPos } from '$lib/functions/format-pos';
 import type { BookmarkManager } from '../types';
+import type { BooksDbBookmarkData } from '$lib/data/database/books-db/versions/books-db';
 import type { CharacterStatsCalculator } from './character-stats-calculator';
+import { formatPos } from '$lib/functions/format-pos';
 
 export class BookmarkManagerContinuous implements BookmarkManager {
-  constructor(private calculator: CharacterStatsCalculator, private window: Window) {}
+  constructor(
+    private calculator: CharacterStatsCalculator,
+    private window: Window,
+    private firstDimensionMargin: number
+  ) {}
 
   scrollToBookmark(bookmarkData: BooksDbBookmarkData) {
     const targetScroll = this.getBookmarkPosition(bookmarkData);
     if (!targetScroll) return;
 
-    const { scrollToData } = resolveTargetScroll(targetScroll);
+    const { scrollToData } = resolveTargetScroll(targetScroll, this.firstDimensionMargin);
     this.window.scrollTo(scrollToData);
   }
 
@@ -39,7 +43,7 @@ export class BookmarkManagerContinuous implements BookmarkManager {
     const targetScroll = this.getBookmarkPosition(bookmarkData);
     if (!targetScroll) return undefined;
 
-    return resolveTargetScroll(targetScroll).bookmarkPosData;
+    return resolveTargetScroll(targetScroll, this.firstDimensionMargin).bookmarkPosData;
   }
 
   private getBookmarkPosition(bookmark: BooksDbBookmarkData): TargetScroll | undefined {
@@ -81,7 +85,10 @@ export class BookmarkManagerContinuous implements BookmarkManager {
   }
 }
 
-function resolveTargetScroll(targetScroll: TargetScroll): {
+function resolveTargetScroll(
+  targetScroll: TargetScroll,
+  dimensionAdjustment: number
+): {
   bookmarkPosData: BookmarkPosData;
   scrollToData: ScrollToOptions;
 } {
@@ -91,7 +98,7 @@ function resolveTargetScroll(targetScroll: TargetScroll): {
         left: targetScroll.scrollX
       },
       bookmarkPosData: {
-        right: `${-targetScroll.scrollX}px`
+        right: `${-targetScroll.scrollX + dimensionAdjustment}px`
       }
     };
   }
@@ -100,7 +107,7 @@ function resolveTargetScroll(targetScroll: TargetScroll): {
       top: targetScroll.scrollY
     },
     bookmarkPosData: {
-      top: `${targetScroll.scrollY}px`
+      top: `${targetScroll.scrollY + dimensionAdjustment}px`
     }
   };
 }

--- a/apps/web/src/lib/components/book-reader/book-reader-continuous/character-stats-calculator.ts
+++ b/apps/web/src/lib/components/book-reader/book-reader-continuous/character-stats-calculator.ts
@@ -49,7 +49,12 @@ export class CharacterStatsCalculator {
       this.verticalMode ? scrollElRect.right : scrollElRect.top,
       this.direction
     );
-
+    const dimensionAdjustment = Number(
+      getComputedStyle(this.containerEl)[this.verticalMode ? 'paddingRight' : 'paddingTop'].replace(
+        /px$/,
+        ''
+      )
+    );
     const paragraphPosToIndices = new Map<number, number[]>();
     for (let i = 0; i < this.paragraphs.length; i += 1) {
       const node = this.paragraphs[i];
@@ -59,7 +64,7 @@ export class CharacterStatsCalculator {
         this.verticalMode ? nodeRect.left : nodeRect.bottom,
         this.direction
       );
-      const paragraphPos = nodeLeft - scrollElRight + scrollPos;
+      const paragraphPos = nodeLeft - scrollElRight - dimensionAdjustment + scrollPos;
       this.paragraphPos[i] = paragraphPos;
 
       const indices = paragraphPosToIndices.get(paragraphPos) || [];


### PR DESCRIPTION
currently the bookmark position and character calculation ignores any configured margin in the continous mode.

Adding it into their calculations may have a better behavior 

see also https://renji-xd.github.io/ebook-reader/