### PR TITLE
fix: close backdrop of dialogManager properly

### DIFF
--- a/apps/web/src/lib/components/book-reader/book-toc/book-toc.svelte
+++ b/apps/web/src/lib/components/book-reader/book-toc/book-toc.svelte
@@ -92,15 +92,19 @@
     nextChapter$.next(chapterId);
 
     if (closeToc) {
-      tocIsOpen$.next(false);
-      dialogManager.dialogs$.next([]);
+      closeTocMenu();
     }
+  }
+
+  function closeTocMenu() {
+    tocIsOpen$.next(false);
+    dialogManager.dialogs$.next([]);
   }
 </script>
 
 <div class="flex justify-between p-4">
   <div>Chapter Progress: {currentChapterCharacterProgress} ({currentChapterProgress}%)</div>
-  <div class="cursor-pointer" on:click={() => tocIsOpen$.next(false)}>
+  <div class="flex cursor-pointer items-end md:items-center" on:click={closeTocMenu}>
     <Fa icon={faXmark} />
   </div>
 </div>


### PR DESCRIPTION
Currently backdrop of dialogManager stays open for the Case in which the toc is closed by its close icon

https://renji-xd.github.io/ebook-reader/manage