### PR TITLE
fix: Fixed incorrect page rendering in horizontal paginated mode on ios.

### DIFF
--- a/apps/web/src/lib/components/book-reader/book-reader-paginated/book-reader-paginated.svelte
+++ b/apps/web/src/lib/components/book-reader/book-reader-paginated/book-reader-paginated.svelte
@@ -383,6 +383,9 @@
   style:--book-content-hint-furigana-shadow-color={hintFuriganaShadowColor}
   style:--book-content-child-width="{width}px"
   style:--book-content-child-height="{height}px"
+  style:--book-content-child-width-single-column={!verticalMode && columnCount === 1
+    ? `${width}px`
+    : undefined}
   style:--book-content-column-count={columnCount}
   style:--book-content-image-max-width="{verticalMode
     ? width
@@ -432,6 +435,10 @@
 
   .book-content-container {
     column-count: var(--book-content-column-count, 1);
+    column-width: var(
+      --book-content-child-width-single-column,
+      auto
+    ); //necessary for the page to render correctly on ios
     column-gap: 20px;
     column-fill: auto;
     height: var(--book-content-child-height, 95vh);

--- a/apps/web/src/lib/components/book-reader/book-reader-paginated/book-reader-paginated.svelte
+++ b/apps/web/src/lib/components/book-reader/book-reader-paginated/book-reader-paginated.svelte
@@ -383,7 +383,7 @@
   style:--book-content-hint-furigana-shadow-color={hintFuriganaShadowColor}
   style:--book-content-child-width="{width}px"
   style:--book-content-child-height="{height}px"
-  style:--book-content-child-width-single-column={!verticalMode && columnCount === 1 ? `${width}px` : undefined}
+  style:--book-content-child-column-width={!verticalMode && columnCount === 1 ? `${width}px` : ''}
   style:--book-content-column-count={columnCount}
   style:--book-content-image-max-width="{verticalMode
     ? width
@@ -433,7 +433,7 @@
 
   .book-content-container {
     column-count: var(--book-content-column-count, 1);
-    column-width: var(--book-content-child-width-single-column, auto); //necessary for the page to render correctly on ios
+    column-width: var(--book-content-child-column-width, auto); // required for WebKit + column-count 1
     column-gap: 20px;
     column-fill: auto;
     height: var(--book-content-child-height, 95vh);

--- a/apps/web/src/lib/components/book-reader/book-reader-paginated/book-reader-paginated.svelte
+++ b/apps/web/src/lib/components/book-reader/book-reader-paginated/book-reader-paginated.svelte
@@ -383,9 +383,7 @@
   style:--book-content-hint-furigana-shadow-color={hintFuriganaShadowColor}
   style:--book-content-child-width="{width}px"
   style:--book-content-child-height="{height}px"
-  style:--book-content-child-width-single-column={!verticalMode && columnCount === 1
-    ? `${width}px`
-    : undefined}
+  style:--book-content-child-width-single-column={!verticalMode && columnCount === 1 ? `${width}px` : undefined}
   style:--book-content-column-count={columnCount}
   style:--book-content-image-max-width="{verticalMode
     ? width
@@ -435,10 +433,7 @@
 
   .book-content-container {
     column-count: var(--book-content-column-count, 1);
-    column-width: var(
-      --book-content-child-width-single-column,
-      auto
-    ); //necessary for the page to render correctly on ios
+    column-width: var(--book-content-child-width-single-column, auto); //necessary for the page to render correctly on ios
     column-gap: 20px;
     column-fill: auto;
     height: var(--book-content-child-height, 95vh);


### PR DESCRIPTION
I opened an issue a couple of days ago about this problem and I think this is a fix for it.
Details can be found here: https://github.com/ttu-ttu/ebook-reader/issues/170

I added the attribute `column-width` to `.book-content-container` and I set it to `auto` when the columns are more than one and to the width of the page if there is only one column. This fixes a problem that only happens on mobile ios when `column-count` is set to value `1`. This bug makes the page load vertically instead of horizontally causing the reader to be unusable, since vertical scrolling is disabled.

I found the solution here: https://stackoverflow.com/questions/71319077/columns-or-column-count-1-not-working-safari .

I tested it and it works both on mobile and on chrome browser on pc.