### PR TITLE
refactor: tabbed like settings view and background color for active

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,25 @@ You may find the following controls in the manager:
 | ![Icon](assets/readme/control-bookselection.svg) | Selects all books                                                          |
 | ![Icon](assets/readme/control-file-upload.svg)   | Allows you to import new books to the library                              |
 | ![Icon](assets/readme/control-folder-upload.svg) | Allows you to import new books from a folder to the library (desktop only) |
-| ![Icon](assets/readme/control-settings.svg)      | Navigates you to the settings                                              |
 | ![Icon](assets/readme/control-log.svg)           | Allows you to download data for a bug report                               |
+| ![Icon](assets/readme/control-settings.svg)      | Navigates you to the settings                                              |
 | ![Icon](assets/readme/control-manager.svg)       | Opens the action menu                                                      |
+
+# Storage Limits
+
+Data like books or bookmarks will be stored locally in your browser storage. Browsers typically apply certain limits on how much a website
+can store on your computer. Those limits are different across different browsers and options you may have enabled.
+
+> When the available disk space is filled up, the quota manager will start clearing out data based on an LRU policy — the least recently used origin will be
+> deleted first, then the next one, until the browser is no longer over the limit.
+
+Therefore your data can be lost based on the amount you stored and how much storage is available. In order to overcome this limitation ttu reader
+will try to request for persistant storage during data insertion. You can enable persistant storage in the reader settings. Based on your browser you will
+see different behavior. E. g. firefox will ask you for your confirmation while chrome will not display any dialog but automatically grant the permissions if you frequently interacted with / bookmarked the page and / or have granted notification permissions to the site
+
+**Note**: Other browsers may have additional criteria for data eviction which are not affected by this setting. E. g. iOS > 13.3 may delete all your page data if you haven't interacted with the reader for 7 days etc.
+
+For more Information and Details check out this [Documentation](https://web.dev/storage-for-the-web/#how-much)
 
 # Self Host
 

--- a/apps/web/src/lib/components/button-toggle-group/button-toggle-group.svelte
+++ b/apps/web/src/lib/components/button-toggle-group/button-toggle-group.svelte
@@ -18,8 +18,12 @@
 <div class="-m-1">
   {#each options as option}
     <button
-      class="m-1 rounded-md border border-gray-400 bg-white p-2 text-lg"
+      class="m-1 rounded-md border-2 border-gray-400 p-2 text-lg"
+      class:border-4={option.thickBorders && option.id === selectedOptionId}
       class:border-blue-300={option.id === selectedOptionId}
+      class:bg-gray-700={option.id === selectedOptionId}
+      class:text-white={option.id === selectedOptionId}
+      class:bg-white={option.id !== selectedOptionId}
       style={mapToStyleString(option.style)}
       on:click={() => (selectedOptionId = option.id)}
     >

--- a/apps/web/src/lib/components/button-toggle-group/toggle-option.ts
+++ b/apps/web/src/lib/components/button-toggle-group/toggle-option.ts
@@ -8,4 +8,5 @@ export interface ToggleOption<T> {
   id: T;
   text: string;
   style?: Record<string, string>;
+  thickBorders?: boolean;
 }

--- a/apps/web/src/lib/components/settings/settings-content.svelte
+++ b/apps/web/src/lib/components/settings/settings-content.svelte
@@ -41,6 +41,8 @@
 
   export let autoBookmark: boolean;
 
+  export let activeSettings: string;
+
   const availableThemes = Array.from(availableThemesMap.entries()).map(([theme, option]) => ({
     theme,
     option
@@ -52,7 +54,8 @@
     style: {
       color: option.fontColor,
       'background-color': option.backgroundColor
-    }
+    },
+    thickBorders: true
   }));
 
   const optionsForToggle: ToggleOption<boolean>[] = [
@@ -120,92 +123,109 @@
   $: avoidPageBreakTooltip = avoidPageBreak
     ? 'Avoids breaking words/sentences into different pages'
     : 'Allow words/sentences to break into different pages';
+  $: persistentStorageTooltip = persistentStorage
+    ? 'Reader uses higher storage limit'
+    : 'Uses lower temporary storage.\nMay require bookmark or notification permissions for enablement';
 </script>
 
 <div class="grid grid-cols-1 items-center sm:grid-cols-2 sm:gap-6 lg:grid-cols-3 lg:md:gap-8">
-  <div class="sm:col-span-2 lg:col-span-3">
-    <SettingsItemGroup title="Theme">
-      <ButtonToggleGroup options={optionsForTheme} bind:selectedOptionId={selectedTheme} />
-    </SettingsItemGroup>
-  </div>
-  <SettingsItemGroup title="Font size">
-    <input type="number" class={inputClasses} step="1" min="1" bind:value={fontSize} />
-  </SettingsItemGroup>
-  <SettingsItemGroup title="Font family (Group 1)">
-    <input
-      type="text"
-      class={inputClasses}
-      placeholder="Noto Serif JP"
-      bind:value={fontFamilyGroupOne}
-    />
-  </SettingsItemGroup>
-  <SettingsItemGroup title="Font family (Group 2)">
-    <input
-      type="text"
-      class={inputClasses}
-      placeholder="Noto Sans JP"
-      bind:value={fontFamilyGroupTwo}
-    />
-  </SettingsItemGroup>
-  <SettingsItemGroup title={verticalMode ? 'Reader Left/right margin' : 'Reader Top/bottom margin'}>
-    <SettingsDimensionPopover
-      slot="header"
-      isFirstDimension
-      isVertical={verticalMode}
-      bind:dimensionValue={firstDimensionMargin}
-    />
-    <input type="number" class={inputClasses} step="1" min="0" bind:value={firstDimensionMargin} />
-  </SettingsItemGroup>
-  <SettingsItemGroup title={verticalMode ? 'Reader Max height' : 'Reader Max width'}>
-    <SettingsDimensionPopover
-      slot="header"
-      isVertical={verticalMode}
-      bind:dimensionValue={secondDimensionMaxValue}
-    />
-    <input
-      type="number"
-      class={inputClasses}
-      step="1"
-      min="0"
-      bind:value={secondDimensionMaxValue}
-    />
-  </SettingsItemGroup>
-  <SettingsItemGroup title="View mode">
-    <ButtonToggleGroup options={optionsForViewMode} bind:selectedOptionId={viewMode} />
-  </SettingsItemGroup>
-  <SettingsItemGroup title="Writing mode">
-    <ButtonToggleGroup options={optionsForWritingMode} bind:selectedOptionId={writingMode} />
-  </SettingsItemGroup>
-  <SettingsItemGroup
-    title="Auto Bookmark"
-    tooltip={'Set a bookmark after 3 seconds without scrolling/page change'}
-  >
-    <ButtonToggleGroup options={optionsForToggle} bind:selectedOptionId={autoBookmark} />
-  </SettingsItemGroup>
-  <SettingsItemGroup title="Blur image">
-    <ButtonToggleGroup options={optionsForToggle} bind:selectedOptionId={blurImage} />
-  </SettingsItemGroup>
-  <SettingsItemGroup title="Hide furigana">
-    <ButtonToggleGroup options={optionsForToggle} bind:selectedOptionId={hideFurigana} />
-  </SettingsItemGroup>
-  <SettingsItemGroup title="Hide furigana style" tooltip={furiganaStyleTooltip}>
-    <ButtonToggleGroup options={optionsForFuriganaStyle} bind:selectedOptionId={furiganaStyle} />
-  </SettingsItemGroup>
-  <SettingsItemGroup title="Persistent storage">
-    <ButtonToggleGroup options={optionsForToggle} bind:selectedOptionId={persistentStorage} />
-  </SettingsItemGroup>
-  {#if viewMode === ViewMode.Continuous}
-    <SettingsItemGroup title="Auto position on resize">
-      <ButtonToggleGroup options={optionsForToggle} bind:selectedOptionId={autoPositionOnResize} />
-    </SettingsItemGroup>
-  {:else}
-    <SettingsItemGroup title="Avoid Page Break" tooltip={avoidPageBreakTooltip}>
-      <ButtonToggleGroup options={optionsForToggle} bind:selectedOptionId={avoidPageBreak} />
-    </SettingsItemGroup>
-    {#if !verticalMode}
-      <SettingsItemGroup title="Page Columns">
-        <input type="number" class={inputClasses} step="1" min="0" bind:value={pageColumns} />
+  {#if activeSettings === 'Reader'}
+    <div class="sm:col-span-2 lg:col-span-3">
+      <SettingsItemGroup title="Theme">
+        <ButtonToggleGroup options={optionsForTheme} bind:selectedOptionId={selectedTheme} />
       </SettingsItemGroup>
+    </div>
+    <SettingsItemGroup title="Font size">
+      <input type="number" class={inputClasses} step="1" min="1" bind:value={fontSize} />
+    </SettingsItemGroup>
+    <SettingsItemGroup title="Font family (Group 1)">
+      <input
+        type="text"
+        class={inputClasses}
+        placeholder="Noto Serif JP"
+        bind:value={fontFamilyGroupOne}
+      />
+    </SettingsItemGroup>
+    <SettingsItemGroup title="Font family (Group 2)">
+      <input
+        type="text"
+        class={inputClasses}
+        placeholder="Noto Sans JP"
+        bind:value={fontFamilyGroupTwo}
+      />
+    </SettingsItemGroup>
+    <SettingsItemGroup
+      title={verticalMode ? 'Reader Left/right margin' : 'Reader Top/bottom margin'}
+    >
+      <SettingsDimensionPopover
+        slot="header"
+        isFirstDimension
+        isVertical={verticalMode}
+        bind:dimensionValue={firstDimensionMargin}
+      />
+      <input
+        type="number"
+        class={inputClasses}
+        step="1"
+        min="0"
+        bind:value={firstDimensionMargin}
+      />
+    </SettingsItemGroup>
+    <SettingsItemGroup title={verticalMode ? 'Reader Max height' : 'Reader Max width'}>
+      <SettingsDimensionPopover
+        slot="header"
+        isVertical={verticalMode}
+        bind:dimensionValue={secondDimensionMaxValue}
+      />
+      <input
+        type="number"
+        class={inputClasses}
+        step="1"
+        min="0"
+        bind:value={secondDimensionMaxValue}
+      />
+    </SettingsItemGroup>
+    <SettingsItemGroup title="View mode">
+      <ButtonToggleGroup options={optionsForViewMode} bind:selectedOptionId={viewMode} />
+    </SettingsItemGroup>
+    <SettingsItemGroup title="Writing mode">
+      <ButtonToggleGroup options={optionsForWritingMode} bind:selectedOptionId={writingMode} />
+    </SettingsItemGroup>
+    <SettingsItemGroup
+      title="Auto Bookmark"
+      tooltip={'Set a bookmark after 3 seconds without scrolling/page change'}
+    >
+      <ButtonToggleGroup options={optionsForToggle} bind:selectedOptionId={autoBookmark} />
+    </SettingsItemGroup>
+    <SettingsItemGroup title="Blur image">
+      <ButtonToggleGroup options={optionsForToggle} bind:selectedOptionId={blurImage} />
+    </SettingsItemGroup>
+    <SettingsItemGroup title="Hide furigana">
+      <ButtonToggleGroup options={optionsForToggle} bind:selectedOptionId={hideFurigana} />
+    </SettingsItemGroup>
+    <SettingsItemGroup title="Hide furigana style" tooltip={furiganaStyleTooltip}>
+      <ButtonToggleGroup options={optionsForFuriganaStyle} bind:selectedOptionId={furiganaStyle} />
+    </SettingsItemGroup>
+    {#if viewMode === ViewMode.Continuous}
+      <SettingsItemGroup title="Auto position on resize">
+        <ButtonToggleGroup
+          options={optionsForToggle}
+          bind:selectedOptionId={autoPositionOnResize}
+        />
+      </SettingsItemGroup>
+    {:else}
+      <SettingsItemGroup title="Avoid Page Break" tooltip={avoidPageBreakTooltip}>
+        <ButtonToggleGroup options={optionsForToggle} bind:selectedOptionId={avoidPageBreak} />
+      </SettingsItemGroup>
+      {#if !verticalMode}
+        <SettingsItemGroup title="Page Columns">
+          <input type="number" class={inputClasses} step="1" min="0" bind:value={pageColumns} />
+        </SettingsItemGroup>
+      {/if}
     {/if}
+  {:else}
+    <SettingsItemGroup title="Persistent storage" tooltip={persistentStorageTooltip}>
+      <ButtonToggleGroup options={optionsForToggle} bind:selectedOptionId={persistentStorage} />
+    </SettingsItemGroup>
   {/if}
 </div>

--- a/apps/web/src/lib/components/settings/settings-header.svelte
+++ b/apps/web/src/lib/components/settings/settings-header.svelte
@@ -1,12 +1,41 @@
 <script lang="ts">
+  import { faBookOpenReader, faDatabase } from '@fortawesome/free-solid-svg-icons';
+  import Fa from 'svelte-fa';
   import MergedHeaderIcon from '$lib/components/merged-header-icon/merged-header-icon.svelte';
+  import Ripple from '$lib/components/ripple.svelte';
   import { baseHeaderClasses, pxScreen } from '$lib/css-classes';
 
   export let leavePageLink: string;
+  export let activeSettings: string;
+
+  const settingItems = [
+    {
+      label: 'Reader',
+      icon: faBookOpenReader
+    },
+    {
+      label: 'Data',
+      icon: faDatabase
+    }
+  ];
 </script>
 
 <div class={baseHeaderClasses}>
-  <div class="flex grow items-center justify-end {pxScreen} px-0 md:px-5">
+  <div class="{pxScreen} flex px-0 md:px-5">
+    <div class="h12 flex grow justify-evenly xl:h-10">
+      {#each settingItems as settingItem (settingItem.label)}
+        <button
+          class="flex grow flex-col items-center justify-center text-xs"
+          class:bg-gray-900={activeSettings === settingItem.label}
+          class:hover:bg-gray-900={activeSettings !== settingItem.label}
+          on:click={() => (activeSettings = settingItem.label)}
+        >
+          <Fa class="mb-1" icon={settingItem.icon} />
+          {settingItem.label}
+          <Ripple />
+        </button>
+      {/each}
+    </div>
     <MergedHeaderIcon {leavePageLink} />
   </div>
 </div>

--- a/apps/web/src/lib/components/settings/settings-item-group.svelte
+++ b/apps/web/src/lib/components/settings/settings-item-group.svelte
@@ -11,9 +11,8 @@
   <div class="flex">
     <h2 class="mb-2 text-xl font-medium">
       {#if tooltip}
-        <Popover>
+        <Popover contentText={tooltip} contentStyles="padding: 0.5rem;">
           <Fa icon={faCircleQuestion} slot="icon" class="mx-2" />
-          <div slot="content" class="p-2">{tooltip}</div>
           <span class="capitalize">{title}</span>
         </Popover>
       {:else}

--- a/apps/web/src/routes/settings/index.svelte
+++ b/apps/web/src/routes/settings/index.svelte
@@ -35,6 +35,9 @@
   });
 
   let prevPage = '/manage';
+
+  let activeSettings = 'Reader';
+
   afterNavigate((navigation) => {
     const { from } = navigation;
     if (!from) return;
@@ -66,12 +69,13 @@
 </svelte:head>
 
 <div class="elevation-4 fixed inset-x-0 top-0 z-10">
-  <SettingsHeader leavePageLink={prevPage} />
+  <SettingsHeader leavePageLink={prevPage} bind:activeSettings />
 </div>
 
 <div class="{pxScreen} h-full pt-16 xl:pt-14">
   <div class="max-w-5xl">
     <SettingsContent
+      {activeSettings}
       bind:selectedTheme={$theme$}
       bind:fontSize={$fontSize$}
       bind:fontFamilyGroupOne={$fontFamilyGroupOne$}


### PR DESCRIPTION
Amount of Settings are growing and there will potentially also be list like data for backlog items like timer, notes etc.
Some of them may be separate pages but for some it may make sense to keep it in settings context. PR adds a tab like UX in order to lower the overload / scrolling of a one single screen.

Also adds background color for active items of settings groups + thicker border for the theme group which could close potentially #163  

Also added a Section in the Readme to explain storage limits etc. for user awareness.

https://renji-xd.github.io/ebook-reader/settings
https://github.com/Renji-XD/ebook-reader/tree/reader_demo_svelte