### PR TITLE
refactor: add book timestamps and sort order

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Explanation from [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Keyboard
 
 You can open the book manager by clicking/tapping on the respective icon in the reader.
 You will be presented with a list of covers for all the imported books with their respective titles and progress (determined
-by bookmark location).
+by bookmark location). Books are sorted in following priority: last opened/read > last modified/added > no time data stored.
 
 You may:
 

--- a/apps/web/src/lib/components/book-card/book-card-list.svelte
+++ b/apps/web/src/lib/components/book-card/book-card-list.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-  import { faCheckCircle } from '@fortawesome/free-solid-svg-icons';
+  import { faCheckCircle, faCircleInfo } from '@fortawesome/free-solid-svg-icons';
+  import BookCard from '$lib/components/book-card/book-card.svelte';
+  import type { BookCardProps } from '$lib/components/book-card/book-card-props';
+  import Popover from '$lib/components/popover/popover.svelte';
   import { createEventDispatcher } from 'svelte';
   import Fa from 'svelte-fa';
-  import type { BookCardProps } from './book-card-props';
-  import BookCard from './book-card.svelte';
 
   export let bookCards: BookCardProps[] = [];
   export let currentBookId: number | undefined;
@@ -22,6 +23,10 @@
 
   function onBookCardClick(id: number) {
     dispatch('bookClick', { id });
+  }
+
+  function getCardDateInfo(dateTime: number) {
+    return dateTime ? new Date(dateTime).toLocaleString() : 'No Data';
   }
 </script>
 
@@ -48,7 +53,25 @@
           </div>
         {/if}
       </div>
-
+      {#if selectedBookIds.has(bookCard.id)}
+        <div class="absolute top-10 left-2">
+          <Popover placement="right" fallbackPlacements={['bottom']} yOffset={5}>
+            <Fa
+              slot="icon"
+              class="mdc-elevation--z2 hover:mdc-elevation--z8 mdc-elevation-transition left-2 top-10 rounded-full bg-blue-400 text-xl text-white"
+              icon={faCircleInfo}
+            />
+            <div class="p-4" slot="content">
+              <div>Last Read:</div>
+              <div class="w-40">{getCardDateInfo(bookCard.lastBookOpen)}</div>
+              <div class="mt-4">Bookmarked:</div>
+              <div class="w-40">{getCardDateInfo(bookCard.lastBookmarkModified)}</div>
+              <div class="mt-4">Last Update:</div>
+              <div class="w-40">{getCardDateInfo(bookCard.lastBookModified)}</div>
+            </div>
+          </Popover>
+        </div>
+      {/if}
       {#if bookCard.id === hoveringBookId}
         <div
           class="mdc-elevation--z2 hover:mdc-elevation--z8 mdc-elevation-transition absolute -top-2 -right-2 h-6 w-6 cursor-pointer rounded-full bg-red-400"

--- a/apps/web/src/lib/components/book-card/book-card-props.ts
+++ b/apps/web/src/lib/components/book-card/book-card-props.ts
@@ -8,5 +8,8 @@ export interface BookCardProps {
   id: number;
   imagePath: string | Blob;
   title: string;
+  lastBookModified: number;
+  lastBookOpen: number;
   progress: number;
+  lastBookmarkModified: number;
 }

--- a/apps/web/src/lib/components/book-reader/book-reader-continuous/bookmark-manager-continuous.ts
+++ b/apps/web/src/lib/components/book-reader/book-reader-continuous/bookmark-manager-continuous.ts
@@ -35,7 +35,8 @@ export class BookmarkManagerContinuous implements BookmarkManager {
       dataId: bookId,
       exploredCharCount,
       progress: exploredCharCount / bookCharCount,
-      [scrollAxis]: this.window[scrollAxis]
+      [scrollAxis]: this.window[scrollAxis],
+      lastBookmarkModified: new Date().getTime()
     };
   }
 

--- a/apps/web/src/lib/components/book-reader/book-reader-paginated/bookmark-manager-paginated.ts
+++ b/apps/web/src/lib/components/book-reader/book-reader-paginated/bookmark-manager-paginated.ts
@@ -5,8 +5,9 @@
  */
 
 import type { BehaviorSubject, Observable } from 'rxjs';
+
+import type { BookmarkManager } from '$lib/components/book-reader/types';
 import type { BooksDbBookmarkData } from '$lib/data/database/books-db/versions/books-db';
-import type { BookmarkManager } from '../types';
 import type { PageManagerPaginated } from './page-manager-paginated';
 import type { SectionCharacterStatsCalculator } from './section-character-stats-calculator';
 
@@ -52,7 +53,8 @@ export class BookmarkManagerPaginated implements BookmarkManager {
     return {
       dataId: bookId,
       exploredCharCount,
-      progress: exploredCharCount / bookCharCount
+      progress: exploredCharCount / bookCharCount,
+      lastBookmarkModified: new Date().getTime()
     };
   }
 }

--- a/apps/web/src/lib/data/database/books-db/database.service.ts
+++ b/apps/web/src/lib/data/database/books-db/database.service.ts
@@ -116,12 +116,14 @@ export class DatabaseService {
 
     const tx = db.transaction('data', 'readwrite');
     const { store } = tx;
-    const oldId = await store.index('title').getKey(data.title);
+    const oldData = await store.index('title').get(data.title);
 
-    if (oldId) {
+    if (oldData) {
       bookData = {
         ...data,
-        id: oldId
+        id: oldData.id,
+        lastBookModified: data.lastBookModified || oldData.lastBookModified,
+        lastBookOpen: data.lastBookOpen || oldData.lastBookOpen
       };
       dataId = await store.put(bookData);
     } else {

--- a/apps/web/src/lib/data/database/books-db/versions/v2/upgrade.ts
+++ b/apps/web/src/lib/data/database/books-db/versions/v2/upgrade.ts
@@ -5,6 +5,7 @@
  */
 
 import type { IDBPDatabase, IDBPTransaction, StoreNames } from 'idb';
+
 import type BooksDb from '../books-db';
 import type { BooksDbBookData } from '../books-db';
 import type BooksDbV2 from './books-db-v2';
@@ -66,7 +67,9 @@ export default async function upgradeBooksDbFromV2(
         const bookDataWithoutKey: Omit<BooksDbBookData, 'id'> = {
           ...parsedData,
           blobs: {},
-          hasThumb: false
+          hasThumb: false,
+          lastBookModified: 0,
+          lastBookOpen: 0
         };
         const dataId = await transaction
           .objectStore('data')
@@ -77,7 +80,8 @@ export default async function upgradeBooksDbFromV2(
           await transaction.objectStore('bookmark').put({
             dataId,
             scrollX: +scrollX,
-            progress: '0%'
+            progress: '0%',
+            lastBookmarkModified: 0
           });
         }
 

--- a/apps/web/src/lib/data/database/books-db/versions/v3/books-db-v3.ts
+++ b/apps/web/src/lib/data/database/books-db/versions/v3/books-db-v3.ts
@@ -15,6 +15,8 @@ interface BooksDbV3BookData {
   coverImage?: string | Blob;
   hasThumb: boolean;
   sections?: Section[];
+  lastBookModified: number;
+  lastBookOpen: number;
 }
 
 interface BooksDbV3BookmarkData {
@@ -23,6 +25,7 @@ interface BooksDbV3BookmarkData {
   scrollY?: number;
   exploredCharCount?: number;
   progress: number | string | undefined;
+  lastBookmarkModified: number;
 }
 
 export interface Section {

--- a/apps/web/src/lib/data/storage-manager/browser-handler.ts
+++ b/apps/web/src/lib/data/storage-manager/browser-handler.ts
@@ -42,7 +42,10 @@ export class BrowserStorageHandler extends BaseStorageHandler {
     existingFileData.id = book.id;
     existingFileData.title = book.title;
     existingFileData.imagePath = book.coverImage || '';
+    existingFileData.lastBookModified = book.lastBookModified || 0;
+    existingFileData.lastBookOpen = book.lastBookOpen || 0;
     existingFileData.progress = 0;
+    existingFileData.lastBookmarkModified = 0;
 
     this.titleToFileData.set(book.title, existingFileData);
   }

--- a/apps/web/src/lib/functions/file-loaders/epub/load-epub.ts
+++ b/apps/web/src/lib/functions/file-loaders/epub/load-epub.ts
@@ -11,7 +11,11 @@ import generateEpubStyleSheet from './generate-epub-style-sheet';
 import getEpubCoverImageFilename from './get-epub-cover-image-filename';
 import reduceObjToBlobs from '../utils/reduce-obj-to-blobs';
 
-export default async function loadEpub(file: File, document: Document): Promise<LoadData> {
+export default async function loadEpub(
+  file: File,
+  document: Document,
+  lastBookModified: number
+): Promise<LoadData> {
   const { contents, result: data } = await extractEpub(file);
   const result = generateEpubHtml(data, contents, document);
 
@@ -43,6 +47,8 @@ export default async function loadEpub(file: File, document: Document): Promise<
     elementHtml: result.element.innerHTML,
     blobs: blobData,
     coverImage,
-    sections: result.sections
+    sections: result.sections,
+    lastBookModified,
+    lastBookOpen: 0
   };
 }

--- a/apps/web/src/lib/functions/file-loaders/htmlz/load-htmlz.ts
+++ b/apps/web/src/lib/functions/file-loaders/htmlz/load-htmlz.ts
@@ -4,14 +4,18 @@
  * All rights reserved.
  */
 
-import { XMLParser } from 'fast-xml-parser';
 import type { LoadData } from '../types';
-import reduceObjToBlobs from '../utils/reduce-obj-to-blobs';
+import { XMLParser } from 'fast-xml-parser';
 import extractHtmlz from './extract-htmlz';
 import { getFormattedElementHtmlz } from './generate-htmlz-html';
 import getHtmlzCoverImageFilename from './get-htmlz-cover-image-filename';
+import reduceObjToBlobs from '../utils/reduce-obj-to-blobs';
 
-export default async function loadHtmlz(file: File, document: Document): Promise<LoadData> {
+export default async function loadHtmlz(
+  file: File,
+  document: Document,
+  lastBookModified: number
+): Promise<LoadData> {
   const data = await extractHtmlz(file);
   const element = getFormattedElementHtmlz(data, document);
   const parser = new XMLParser();
@@ -38,6 +42,8 @@ export default async function loadHtmlz(file: File, document: Document): Promise
     ...displayData,
     elementHtml: element.innerHTML,
     blobs: blobData,
-    coverImage
+    coverImage,
+    lastBookModified,
+    lastBookOpen: 0
   };
 }

--- a/apps/web/src/lib/functions/replication/import-replication.ts
+++ b/apps/web/src/lib/functions/replication/import-replication.ts
@@ -25,6 +25,7 @@ export async function addBooks(
   const dataIds: number[] = [];
   const limiter = pLimit(1);
   const tasks: Promise<void>[] = [];
+  const lastBookModified = new Date().getTime();
 
   let errorMessage = '';
 
@@ -39,8 +40,8 @@ export async function addBooks(
           throwIfAborted(cancelSignal);
 
           const bookContent = await (file.name.endsWith('.epub')
-            ? loadEpub(file, document)
-            : loadHtmlz(file, document));
+            ? loadEpub(file, document, lastBookModified)
+            : loadHtmlz(file, document, lastBookModified));
 
           replicationProgress$.next({ progressToAdd: 100 });
           currentTitle = bookContent.title;

--- a/apps/web/src/routes/b/index.svelte
+++ b/apps/web/src/routes/b/index.svelte
@@ -62,6 +62,8 @@
     sectionProgress$,
     tocIsOpen$
   } from '$lib/components/book-reader/book-toc/book-toc';
+  import { getStorageHandler } from '$lib/data/storage-manager/storage-manager-factory';
+  import { StorageKey } from '$lib/data/storage-manager/storage-source';
   import { clickOutside } from '$lib/functions/use-click-outside';
   import { onKeydownReader } from './on-keydown-reader';
 
@@ -110,6 +112,14 @@
   const bookData$ = rawBookData$.pipe(
     switchMap((rawBookData) => {
       if (!rawBookData) return EMPTY;
+
+      // eslint-disable-next-line no-param-reassign
+      rawBookData.lastBookOpen = new Date().getTime();
+      getStorageHandler(StorageKey.BROWSER, window)
+        .then((handler) => database.upsertData(rawBookData, handler))
+        .catch(() => {
+          // no-op
+        });
 
       sectionList$.next(rawBookData.sections || []);
 

--- a/apps/web/src/routes/manage/index.svelte
+++ b/apps/web/src/routes/manage/index.svelte
@@ -36,10 +36,12 @@
     map(([dataList, bookmarks]) => {
       const bookmarkMap = keyBy(bookmarks, 'dataId');
 
-      return dataList.map((d) => ({
-        ...d,
-        ...bookmarkToProgress(bookmarkMap.get(d.id))
-      }));
+      return dataList
+        .map((d) => ({
+          ...d,
+          ...bookmarkToProgress(bookmarkMap.get(d.id))
+        }))
+        .sort(sortBookCards);
     }),
     share()
   );
@@ -74,9 +76,25 @@
   function bookmarkToProgress(b: BooksDbBookmarkData | undefined) {
     return b?.progress
       ? {
-          progress: typeof b.progress === 'string' ? +b.progress.slice(0, -1) : b.progress
+          progress: typeof b.progress === 'string' ? +b.progress.slice(0, -1) : b.progress,
+          lastBookmarkModified: b.lastBookmarkModified || 0
         }
-      : { progress: 0 };
+      : { progress: 0, lastBookmarkModified: 0 };
+  }
+
+  function sortBookCards(card1: BookCardProps, card2: BookCardProps) {
+    let sortDiff = 0;
+
+    const { lastBookModified: card1LastModified = 0, lastBookOpen: card1lastOpen = 0 } = card1;
+    const { lastBookModified: card2LastModified = 0, lastBookOpen: card2lastOpen = 0 } = card2;
+
+    if (card1lastOpen || card2lastOpen) {
+      sortDiff = card2lastOpen - card1lastOpen;
+    } else {
+      sortDiff = card2LastModified - card1LastModified;
+    }
+
+    return sortDiff;
   }
 
   function onBookClick(bookId: number) {


### PR DESCRIPTION
PR add timestamps for adding/opening/bookmarking Books and adds sorting to the Manager View (last open > last added > old data). On Top there is a new info Icon on Book Selection which exposes the Data to User as local Datetime String via Popover.

Data can potentially be also used later for simple import/export diff options or similar

https://renji-xd.github.io/ebook-reader/