### PR TITLE
fix: avoid runtime error after vite 3.14

### DIFF
--- a/apps/web/src/lib/data/fullscreen-manager.ts
+++ b/apps/web/src/lib/data/fullscreen-manager.ts
@@ -15,7 +15,9 @@ class FullscreenManager {
     return this.fallbackSpec('fullscreenElement', 'webkitFullscreenElement') ?? null;
   }
 
-  constructor(private document: Document) {}
+  constructor(document: Document) {
+    this.fallbackSpec = fallbackSpec(document);
+  }
 
   // eslint-disable-next-line class-methods-use-this
   async requestFullscreen(el: Element, fullscreenOptions?: FullscreenOptions) {
@@ -30,7 +32,7 @@ class FullscreenManager {
     await fn();
   }
 
-  private fallbackSpec = fallbackSpec(this.document);
+  private fallbackSpec: <P extends keyof Document>(specName: P, alias: string) => Document[P];
 }
 
 function fallbackSpec<T>(obj: T) {

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "./.svelte-kit/tsconfig.json",
   "compilerOptions": {
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
-    "target": "ES2020",
+    "target": "ESNext",
     "module": "ES2022",
     "moduleResolution": "node",
     "strict": true,


### PR DESCRIPTION
which enforces different writing style due to esnext compile target