### PR TITLE
Fix resize bookmark

### DIFF
--- a/apps/web/src/lib/components/book-reader/book-reader-continuous/book-reader-continuous.svelte
+++ b/apps/web/src/lib/components/book-reader/book-reader-continuous/book-reader-continuous.svelte
@@ -341,7 +341,7 @@
       if (!calculator) return;
 
       exploredCharCount = calculator.calcExploredCharCount();
-      console.log('scroll', exploredCharCount);
+
       if (!isResizeScroll) {
         prevIntendedCharCount = exploredCharCount;
       }

--- a/apps/web/src/lib/components/book-reader/book-reader-continuous/book-reader-continuous.svelte
+++ b/apps/web/src/lib/components/book-reader/book-reader-continuous/book-reader-continuous.svelte
@@ -247,6 +247,8 @@
           if (!data || !bookmarkManager) {
             return;
           }
+
+          prevIntendedCharCount = data.exploredCharCount || 0;
           bookmarkManager.scrollToBookmark(data);
         })
         .finally(() => {
@@ -339,6 +341,7 @@
       if (!calculator) return;
 
       exploredCharCount = calculator.calcExploredCharCount();
+      console.log('scroll', exploredCharCount);
       if (!isResizeScroll) {
         prevIntendedCharCount = exploredCharCount;
       }


### PR DESCRIPTION
i think this fixes #181 

reproduceable with current reader site either by minimizing the tab before book is loaded or while resizing it forth and back - book will be on start even if there is a bookmark set.

fix on https://renji-xd.github.io/ebook-reader/manage (you can ignore the export - i did not reverted the wip changes)
