### PR TITLE
Update on docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ docker run --name ebook-reader -d -p 8080:80 ebook-reader
 docker-compose up
 ```
 
-3. Visit [http://localhost:8080](http://localhost:8080) to use the app
+3. Visit [http://localhost:9010](http://localhost:9010) to use the app
 
 ### Using HTTP Hosting App
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,4 +6,5 @@ services:
       context: ./
       dockerfile: ./apps/web/Dockerfile
     ports:
-      - 8080:80
+      - 9010:80
+    restart: always


### PR DESCRIPTION
- Changed the default port of the container, because it was currently using the default port for proxies, which was causing conflict with proxy applications like burpsuite.
- Added new command to make the container always restart if stopped unexpectedly (like power outage).


I tested on my machine and it is working well on port 9010