### PR TITLE
prefer to use scroll position over char count for paginated view bookmark

### DIFF
--- a/apps/web/src/lib/components/book-reader/book-reader-paginated/bookmark-manager-paginated.ts
+++ b/apps/web/src/lib/components/book-reader/book-reader-paginated/bookmark-manager-paginated.ts
@@ -27,7 +27,8 @@ export class BookmarkManagerPaginated implements BookmarkManager {
     const index = this.calculator.getSectionIndexByCharCount(charCount);
 
     const scroll = (calc: SectionCharacterStatsCalculator) => {
-      const scrollPos = calc.getScrollPosByCharCount(charCount);
+      const scrollPos = (calc.getScreenSize() === bookmarkData.screenSize && bookmarkData.scrollPos) 
+        ? bookmarkData.scrollPos : calc.getScrollPosByCharCount(charCount);
       this.pageManager.scrollTo(scrollPos, false);
       this.setIntendedCharCount(charCount);
     };
@@ -55,11 +56,15 @@ export class BookmarkManagerPaginated implements BookmarkManager {
     customReadingPointRange: Range | undefined
   ): BooksDbBookmarkData {
     const exploredCharCount = this.calculator.calcExploredCharCount(customReadingPointRange);
+    const scrollPos = this.calculator.getScrollPos();
+    const screenSize = this.calculator.getScreenSize();
     const bookCharCount = this.calculator.charCount;
 
     return {
       dataId: bookId,
       exploredCharCount,
+      scrollPos,
+      screenSize,
       progress: exploredCharCount / bookCharCount,
       lastBookmarkModified: new Date().getTime()
     };

--- a/apps/web/src/lib/components/book-reader/book-reader-paginated/section-character-stats-calculator.ts
+++ b/apps/web/src/lib/components/book-reader/book-reader-paginated/section-character-stats-calculator.ts
@@ -76,6 +76,14 @@ export class SectionCharacterStatsCalculator {
     return this.getCharCountByScrollPos(this.virtualScrollPos$.getValue() + offset);
   }
 
+  getScrollPos() {
+    return this.virtualScrollPos$.getValue();
+  }
+
+  getScreenSize() {
+    return this.screenSize;
+  }
+
   getCharCountByScrollPos(scrollPos: number) {
     if (!this.calculator) return -1;
     const startCount = this.getSectionStartCount();

--- a/apps/web/src/lib/data/database/books-db/versions/v4/books-db-v4.ts
+++ b/apps/web/src/lib/data/database/books-db/versions/v4/books-db-v4.ts
@@ -28,6 +28,8 @@ interface BooksDbV4BookmarkData {
   scrollX?: number;
   scrollY?: number;
   exploredCharCount?: number;
+  scrollPos?: number;
+  screenSize?: number;
   progress: number | string | undefined;
   lastBookmarkModified: number;
 }


### PR DESCRIPTION
Prevents bookmark from missing the desired location in certain instances such as this

![example](https://github.com/ttu-ttu/ebook-reader/assets/22385238/dfa7e3a8-f652-4c57-a3be-ee121196020a)

by using scroll location rather then paragraph/charCount as the bookmark when possible.