### PR TITLE
Fix/Handle Keycode Possibly Being Blank

### DIFF
--- a/apps/web/src/lib/data/store.ts
+++ b/apps/web/src/lib/data/store.ts
@@ -142,15 +142,25 @@ export const lastExportedTypes$ = writableArrayLocalStorageSubject<StorageDataTy
 
 export const bookReaderKeybindMap$ = writableSubject<BookReaderKeybindMap>({
   KeyB: BookReaderAvailableKeybind.BOOKMARK,
+  b: BookReaderAvailableKeybind.BOOKMARK,
   KeyR: BookReaderAvailableKeybind.JUMP_TO_BOOKMARK,
+  r: BookReaderAvailableKeybind.JUMP_TO_BOOKMARK,
   PageDown: BookReaderAvailableKeybind.NEXT_PAGE,
+  pagedown: BookReaderAvailableKeybind.NEXT_PAGE,
   PageUp: BookReaderAvailableKeybind.PREV_PAGE,
+  pageup: BookReaderAvailableKeybind.PREV_PAGE,
   Space: BookReaderAvailableKeybind.AUTO_SCROLL_TOGGLE,
+  ' ': BookReaderAvailableKeybind.AUTO_SCROLL_TOGGLE,
   KeyA: BookReaderAvailableKeybind.AUTO_SCROLL_INCREASE,
+  a: BookReaderAvailableKeybind.AUTO_SCROLL_INCREASE,
   KeyD: BookReaderAvailableKeybind.AUTO_SCROLL_DECREASE,
+  d: BookReaderAvailableKeybind.AUTO_SCROLL_DECREASE,
   KeyN: BookReaderAvailableKeybind.PREV_CHAPTER,
+  n: BookReaderAvailableKeybind.PREV_CHAPTER,
   KeyM: BookReaderAvailableKeybind.NEXT_CHAPTER,
-  KeyT: BookReaderAvailableKeybind.SET_READING_POINT
+  m: BookReaderAvailableKeybind.NEXT_CHAPTER,
+  KeyT: BookReaderAvailableKeybind.SET_READING_POINT,
+  t: BookReaderAvailableKeybind.SET_READING_POINT
 });
 
 const db = browser ? createBooksDb() : import('fake-indexeddb/auto').then(() => createBooksDb());

--- a/apps/web/src/routes/b/on-keydown-reader.ts
+++ b/apps/web/src/routes/b/on-keydown-reader.ts
@@ -22,7 +22,7 @@ export function onKeydownReader(
   changeChapter: (offset: number) => void,
   handleSetCustomReadingPoint: () => void
 ) {
-  const action = bookReaderKeybindMap[ev.code || ev.key];
+  const action = bookReaderKeybindMap[ev.code || ev.key.toLowerCase()];
 
   switch (action) {
     case BookReaderAvailableKeybind.BOOKMARK: {

--- a/apps/web/src/routes/b/on-keydown-reader.ts
+++ b/apps/web/src/routes/b/on-keydown-reader.ts
@@ -22,7 +22,7 @@ export function onKeydownReader(
   changeChapter: (offset: number) => void,
   handleSetCustomReadingPoint: () => void
 ) {
-  const action = bookReaderKeybindMap[ev.code];
+  const action = bookReaderKeybindMap[ev.code || ev.key];
 
   switch (action) {
     case BookReaderAvailableKeybind.BOOKMARK: {


### PR DESCRIPTION
If using the [Key Mapper](https://github.com/keymapperorg/KeyMapper) app to send keys to the reader, the `event.code` is blank for some reason while the same key is in `event.key`. So this PR fixes that to allow Key Mapper to work with ttu reader. Has been tested locally with a Pixel 6.