### PR TITLE
feat: add preset feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ docker-compose up
 ```sh
 cd apps/web
 pnpm install --frozen-lockfile
+pnpm svelte-kit sync
 pnpm build
 ```
 

--- a/apps/web/src/lib/components/book-reader/book-reader.svelte
+++ b/apps/web/src/lib/components/book-reader/book-reader.svelte
@@ -25,6 +25,7 @@
   import { reactiveElements } from './reactive-elements';
   import type { AutoScroller, BookmarkManager, PageManager } from './types';
   import BookReaderPaginated from './book-reader-paginated/book-reader-paginated.svelte';
+  import { presetStorage, database, bookPresets$ } from '$lib/data/store';
 
   export let htmlContent: string;
 
@@ -147,9 +148,20 @@
     share()
   );
 
+  const currentBookId$ = database.lastItem$.pipe(
+    map((item) => item?.dataId),
+    share()
+  );
+
   $: width$.next(width);
 
   $: height$.next(height);
+
+  currentBookId$.subscribe((bookId) => {
+    if (bookId) {
+      presetStorage.setPreset($bookPresets$[bookId.toString()] ?? 'Global');
+    }
+  });
 
   function getAdjustedWidth(widthValue: number) {
     if (ViewMode.Paginated === viewMode && !verticalMode && secondDimensionMaxValue) {

--- a/apps/web/src/lib/components/settings/settings-content.svelte
+++ b/apps/web/src/lib/components/settings/settings-content.svelte
@@ -3,6 +3,7 @@
   import ButtonToggleGroup from '$lib/components/button-toggle-group/button-toggle-group.svelte';
   import type { ToggleOption } from '$lib/components/button-toggle-group/toggle-option';
   import Ripple from '$lib/components/ripple.svelte';
+  import SettingsPresetDialog from '$lib/components/settings/settings-preset-dialog.svelte';
   import SettingsCustomTheme from '$lib/components/settings/settings-custom-theme.svelte';
   import SettingsDimensionPopover from '$lib/components/settings/settings-dimension-popover.svelte';
   import SettingsFontSelector from '$lib/components/settings/settings-font-selector.svelte';
@@ -24,7 +25,9 @@
     fontFamilyGroupTwo$,
     horizontalCustomReadingPosition$,
     theme$,
-    verticalCustomReadingPosition$
+    verticalCustomReadingPosition$,
+    presetStorage,
+    bookPresets$
   } from '$lib/data/store';
   import { availableThemes as availableThemesMap } from '$lib/data/theme-option';
   import { ViewMode } from '$lib/data/view-mode';
@@ -34,9 +37,11 @@
     ReplicationSaveBehavior,
     AutoReplicationType
   } from '$lib/functions/replication/replication-options';
-  import { faComputer, faPlus } from '@fortawesome/free-solid-svg-icons';
+  import { faComputer, faPlus, faTrash, faPen } from '@fortawesome/free-solid-svg-icons';
   import Fa from 'svelte-fa';
   import { map } from 'rxjs';
+
+  export let bookId: number;
 
   export let selectedTheme: string;
 
@@ -267,10 +272,122 @@
         database.storageSourcesChanged$.next([]);
       });
   }
+
+  let bookName: string = 'Loading...';
+
+  $: presetOptions = bookId ? presetStorage.getPresetList() : ['Global'];
+  $: presetName = $bookPresets$[bookId.toString()] ?? 'Global';
+  $: presetStorage.setPreset(presetName);
+
+  $: presetDeleteStyling =
+    presetName !== 'Global'
+      ? 'border-gray-700 bg-gray-700 text-white'
+      : 'border-gray-300 bg-gray-300 text-gray-400';
+  $: presetRenameStyling = presetName !== 'Global' ? 'text-gray-500' : 'text-gray-300';
+
+  $: presetTooltip = bookId
+    ? 'Select preset to be applied to the current book. Changes to this preset will affect other books using the same preset.'
+    : 'Default preset for loaded books. Changes to this preset will affect other books using the same preset.';
+
+  $: if (bookId) {
+    database.getData(bookId).then((bookData) => {
+      if (bookData) {
+        bookName = bookData.title;
+      } else {
+        bookName = '???';
+      }
+    });
+  }
+
+  function handlePresetChange() {
+    if (bookId) {
+      $bookPresets$[bookId.toString()] = presetName;
+    }
+  }
+
+  function createPreset(newPresetName: string) {
+    presetStorage.createNew(newPresetName);
+    presetStorage.setPreset(newPresetName);
+
+    presetOptions = presetStorage.getPresetList();
+    presetName = newPresetName;
+    handlePresetChange();
+  }
+
+  function renamePreset(newPresetName: string) {
+    presetStorage.rename(newPresetName);
+    presetOptions = presetStorage.getPresetList();
+    presetName = newPresetName;
+  }
+
+  function deletePreset() {
+    presetStorage.delete();
+    presetStorage.setPreset('Global');
+    presetName = 'Global';
+    presetOptions = presetStorage.getPresetList();
+  }
 </script>
 
 <div class="grid grid-cols-1 items-center sm:grid-cols-2 sm:gap-6 lg:md:gap-8 lg:grid-cols-3">
   {#if activeSettings === 'Reader'}
+    <div class="sm:col-span-2 lg:col-span-3">
+      <SettingsItemGroup title="Preset{bookId ? ` for "${bookName}"` : ''}" tooltip={presetTooltip}>
+        <div class="flex flex-wrap">
+          <div class="flex flex-grow">
+            <select class="flex-grow" bind:value={presetName} on:change={handlePresetChange}>
+              {#each presetOptions as option}
+                <option value={option}>{option}</option>
+              {/each}
+            </select>
+            {#if bookId}
+              <button
+                class="m-1 mr-4 rounded-md border-2 border-transparent bg-transparent p-2 text-lg relative overflow-hidden {presetRenameStyling}"
+                disabled={presetName === 'Global'}
+                on:click={() =>
+                  dialogManager.dialogs$.next([
+                    {
+                      component: SettingsPresetDialog,
+                      props: {
+                        affirmativeText: 'Rename',
+                        initValue: presetName,
+                        onConfirm: renamePreset
+                      }
+                    }
+                  ])}
+              >
+                <Fa icon={faPen} slot="icon" class="mx-2" />
+                <Ripple />
+              </button>
+            {/if}
+          </div>
+          {#if bookId}
+            <div class="flex">
+              <button
+                class="m-1 ml-0 sm:ml-1 rounded-md border-2 p-2 text-lg relative overflow-hidden border-gray-700 bg-gray-700 text-white"
+                on:click={() =>
+                  dialogManager.dialogs$.next([
+                    {
+                      component: SettingsPresetDialog,
+                      props: { onConfirm: createPreset }
+                    }
+                  ])}
+              >
+                <Fa icon={faPlus} slot="icon" class="mx-2" />
+                <Ripple />
+              </button>
+              <button
+                class="m-1 rounded-md border-2 p-2 text-lg relative overflow-hidden {presetDeleteStyling}"
+                disabled={presetName === 'Global'}
+                on:click={deletePreset}
+              >
+                <Fa icon={faTrash} slot="icon" class="mx-2" />
+                <Ripple />
+              </button>
+            </div>
+          {/if}
+        </div>
+      </SettingsItemGroup>
+    </div>
     <div class="lg:col-span-2">
       <SettingsItemGroup title="Theme">
         <ButtonToggleGroup

--- a/apps/web/src/lib/components/settings/settings-content.svelte
+++ b/apps/web/src/lib/components/settings/settings-content.svelte
@@ -29,6 +29,7 @@
     presetStorage,
     bookPresets$
   } from '$lib/data/store';
+  import { PresetStorage } from '$lib/data/window/preset-storage';
   import { availableThemes as availableThemesMap } from '$lib/data/theme-option';
   import { ViewMode } from '$lib/data/view-mode';
   import type { WritingMode } from '$lib/data/writing-mode';
@@ -275,7 +276,7 @@
 
   let bookName: string = 'Loading...';
 
-  $: presetOptions = bookId ? presetStorage.getPresetList() : ['Global'];
+  $: presetOptions = bookId ? PresetStorage.getPresetList() : ['Global'];
   $: presetName = $bookPresets$[bookId.toString()] ?? 'Global';
   $: presetStorage.setPreset(presetName);
 
@@ -309,14 +310,14 @@
     presetStorage.createNew(newPresetName);
     presetStorage.setPreset(newPresetName);
 
-    presetOptions = presetStorage.getPresetList();
+    presetOptions = PresetStorage.getPresetList();
     presetName = newPresetName;
     handlePresetChange();
   }
 
   function renamePreset(newPresetName: string) {
     presetStorage.rename(newPresetName);
-    presetOptions = presetStorage.getPresetList();
+    presetOptions = PresetStorage.getPresetList();
     presetName = newPresetName;
   }
 
@@ -324,7 +325,7 @@
     presetStorage.delete();
     presetStorage.setPreset('Global');
     presetName = 'Global';
-    presetOptions = presetStorage.getPresetList();
+    presetOptions = PresetStorage.getPresetList();
   }
 </script>
 

--- a/apps/web/src/lib/components/settings/settings-preset-dialog.svelte
+++ b/apps/web/src/lib/components/settings/settings-preset-dialog.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+  import DialogTemplate from '$lib/components/dialog-template.svelte';
+  import Ripple from '$lib/components/ripple.svelte';
+  import { buttonClasses } from '$lib/css-classes';
+  import { createEventDispatcher, onMount } from 'svelte';
+  import { presetStorage } from '$lib/data/store';
+
+  export let affirmativeText: string = 'Save';
+  export let negativeText: string = 'Cancel';
+  export let initValue: string = '';
+  export let onConfirm: ((presetName: string) => void) | undefined;
+
+  let presetName = initValue;
+  let presetNameElm: HTMLInputElement;
+
+  const dispatch = createEventDispatcher<{
+    close: void;
+  }>();
+
+  onMount(() => {
+    presetNameElm.focus();
+  });
+
+  function handleAffirmative() {
+    presetNameElm.setCustomValidity('');
+
+    if (!presetName) {
+      presetNameElm.setCustomValidity('You have to enter a name!');
+      presetNameElm.reportValidity();
+      return;
+    }
+
+    if (presetStorage.getPresetList().includes(presetName)) {
+      presetNameElm.setCustomValidity('This name is already in use!');
+      presetNameElm.reportValidity();
+      return;
+    }
+
+    dispatch('close');
+
+    if (onConfirm) {
+      onConfirm(presetName);
+    }
+  }
+</script>
+
+<DialogTemplate>
+  <div slot="content">
+    <div
+      class="grid grid-cols-1 gap-2 items-center overflow-auto max-h-[60vh] sm:grid-cols-[auto_auto_5rem] sm:gap-4"
+    >
+      <input
+        class="sm:col-span-2"
+        type="text"
+        placeholder="Preset Name"
+        bind:value={presetName}
+        bind:this={presetNameElm}
+      />
+    </div>
+    <div class="flex mt-4" />
+  </div>
+  <div class="mt-2 flex grow justify-between" slot="footer">
+    <button class={buttonClasses} on:click={() => dispatch('close')}>
+      {negativeText}
+      <Ripple />
+    </button>
+    <button class={buttonClasses} on:click={handleAffirmative}>
+      {affirmativeText}
+      <Ripple />
+    </button>
+  </div>
+</DialogTemplate>

--- a/apps/web/src/lib/components/settings/settings-preset-dialog.svelte
+++ b/apps/web/src/lib/components/settings/settings-preset-dialog.svelte
@@ -3,7 +3,7 @@
   import Ripple from '$lib/components/ripple.svelte';
   import { buttonClasses } from '$lib/css-classes';
   import { createEventDispatcher, onMount } from 'svelte';
-  import { presetStorage } from '$lib/data/store';
+  import { PresetStorage } from '$lib/data/window/preset-storage';
 
   export let affirmativeText: string = 'Save';
   export let negativeText: string = 'Cancel';
@@ -30,7 +30,7 @@
       return;
     }
 
-    if (presetStorage.getPresetList().includes(presetName)) {
+    if (PresetStorage.getPresetList().includes(presetName)) {
       presetNameElm.setCustomValidity('This name is already in use!');
       presetNameElm.reportValidity();
       return;

--- a/apps/web/src/lib/data/internal/writable-boolean-local-storage-subject.ts
+++ b/apps/web/src/lib/data/internal/writable-boolean-local-storage-subject.ts
@@ -5,9 +5,9 @@
  */
 
 import { writableStorageSubject } from './writable-storage-subject';
-import { localStorage } from '../window/local-storage';
+import { localStorage, type LocalStorage } from '../window/local-storage';
 
-export function writableBooleanLocalStorageSubject(storage = localStorage) {
+export function writableBooleanLocalStorageSubject(storage: LocalStorage = localStorage) {
   return writableStorageSubject(
     storage,
     (x) => !!+x,

--- a/apps/web/src/lib/data/internal/writable-number-local-storage-subject.ts
+++ b/apps/web/src/lib/data/internal/writable-number-local-storage-subject.ts
@@ -5,9 +5,9 @@
  */
 
 import { writableStorageSubject } from './writable-storage-subject';
-import { localStorage } from '../window/local-storage';
+import { localStorage, type LocalStorage } from '../window/local-storage';
 
-export function writableNumberLocalStorageSubject(storage = localStorage) {
+export function writableNumberLocalStorageSubject(storage: LocalStorage = localStorage) {
   return writableStorageSubject(
     storage,
     (x) => +x,

--- a/apps/web/src/lib/data/internal/writable-object-local-storage-subject.ts
+++ b/apps/web/src/lib/data/internal/writable-object-local-storage-subject.ts
@@ -4,10 +4,13 @@
  * All rights reserved.
  */
 
-import { localStorage } from '$lib/data/window/local-storage';
+import { localStorage, type LocalStorage } from '$lib/data/window/local-storage';
 import { writableStorageSubject } from '$lib/data/internal/writable-storage-subject';
 
-function createWritableObjectLocalStorageSubject<T>(fallback: string, storage = localStorage) {
+function createWritableObjectLocalStorageSubject<T>(
+  fallback: string,
+  storage: LocalStorage = localStorage
+) {
   return writableStorageSubject(
     storage,
     (x) => JSON.parse(x || fallback) as T,

--- a/apps/web/src/lib/data/internal/writable-string-local-storage-subject.ts
+++ b/apps/web/src/lib/data/internal/writable-string-local-storage-subject.ts
@@ -5,9 +5,11 @@
  */
 
 import { writableStorageSubject } from './writable-storage-subject';
-import { localStorage } from '../window/local-storage';
+import { localStorage, type LocalStorage } from '../window/local-storage';
 
-export function writableStringLocalStorageSubject<T extends string>(storage = localStorage) {
+export function writableStringLocalStorageSubject<T extends string>(
+  storage: LocalStorage = localStorage
+) {
   return writableStorageSubject(
     storage,
     (x) => x as T,

--- a/apps/web/src/lib/data/store.ts
+++ b/apps/web/src/lib/data/store.ts
@@ -25,73 +25,110 @@ import {
   writableObjectLocalStorageSubject
 } from './internal/writable-object-local-storage-subject';
 import { writableStringLocalStorageSubject } from './internal/writable-string-local-storage-subject';
+import { PresetStorage } from './window/preset-storage';
 import type { ThemeOption } from './theme-option';
 import { ViewMode } from './view-mode';
 import type { WritingMode } from './writing-mode';
 
-export const theme$ = writableStringLocalStorageSubject()('theme', 'light-theme');
+export const bookPresets$ = writableObjectLocalStorageSubject<Record<string, string>>()(
+  'bookPresets',
+  {}
+);
+export const presetStorage = new PresetStorage('Global', bookPresets$);
+
+export const theme$ = writableStringLocalStorageSubject(presetStorage)('theme', 'light-theme');
 export const customThemes$ = writableObjectLocalStorageSubject<Record<string, ThemeOption>>()(
   'customThemes',
   {}
 );
 export const multiplier$ = writableNumberLocalStorageSubject()('autoScrollMultiplier', 20);
-export const fontFamilyGroupOne$ = writableStringLocalStorageSubject()('fontFamilyGroupOne', '');
-export const fontFamilyGroupTwo$ = writableStringLocalStorageSubject()('fontFamilyGroupTwo', '');
-export const fontSize$ = writableNumberLocalStorageSubject()('fontSize', 20);
-export const lineHeight$ = writableNumberLocalStorageSubject()('lineHeight', 1.65);
-export const hideSpoilerImage$ = writableBooleanLocalStorageSubject()('hideSpoilerImage', true);
-export const hideFurigana$ = writableBooleanLocalStorageSubject()('hideFurigana', false);
-export const furiganaStyle$ = writableStringLocalStorageSubject<FuriganaStyle>()(
+export const fontFamilyGroupOne$ = writableStringLocalStorageSubject(presetStorage)(
+  'fontFamilyGroupOne',
+  ''
+);
+export const fontFamilyGroupTwo$ = writableStringLocalStorageSubject(presetStorage)(
+  'fontFamilyGroupTwo',
+  ''
+);
+export const fontSize$ = writableNumberLocalStorageSubject(presetStorage)('fontSize', 20);
+export const lineHeight$ = writableNumberLocalStorageSubject(presetStorage)('lineHeight', 1.65);
+export const hideSpoilerImage$ = writableBooleanLocalStorageSubject(presetStorage)(
+  'hideSpoilerImage',
+  true
+);
+export const hideFurigana$ = writableBooleanLocalStorageSubject(presetStorage)(
+  'hideFurigana',
+  false
+);
+export const furiganaStyle$ = writableStringLocalStorageSubject<FuriganaStyle>(presetStorage)(
   'furiganaStyle',
   FuriganaStyle.Partial
 );
-export const writingMode$ = writableStringLocalStorageSubject<WritingMode>()(
+export const writingMode$ = writableStringLocalStorageSubject<WritingMode>(presetStorage)(
   'writingMode',
   'vertical-rl'
 );
 export const verticalMode$ = writingMode$.pipe(map((writingMode) => writingMode === 'vertical-rl'));
-export const viewMode$ = writableStringLocalStorageSubject<ViewMode>()(
+export const viewMode$ = writableStringLocalStorageSubject<ViewMode>(presetStorage)(
   'viewMode',
   ViewMode.Paginated
 );
 
-export const secondDimensionMaxValue$ = writableNumberLocalStorageSubject()(
+export const secondDimensionMaxValue$ = writableNumberLocalStorageSubject(presetStorage)(
   'secondDimensionMaxValue',
   0
 );
-export const firstDimensionMargin$ = writableNumberLocalStorageSubject()('firstDimensionMargin', 0);
+export const firstDimensionMargin$ = writableNumberLocalStorageSubject(presetStorage)(
+  'firstDimensionMargin',
+  0
+);
 
-export const swipeThreshold$ = writableNumberLocalStorageSubject()('swipeThreshold', 10);
+export const swipeThreshold$ = writableNumberLocalStorageSubject(presetStorage)(
+  'swipeThreshold',
+  10
+);
 
-export const disableWheelNavigation$ = writableBooleanLocalStorageSubject()(
+export const disableWheelNavigation$ = writableBooleanLocalStorageSubject(presetStorage)(
   'disableWheelNavigation',
   false
 );
 
-export const autoPositionOnResize$ = writableBooleanLocalStorageSubject()(
+export const autoPositionOnResize$ = writableBooleanLocalStorageSubject(presetStorage)(
   'autoPositionOnResize',
   true
 );
 
-export const avoidPageBreak$ = writableBooleanLocalStorageSubject()('avoidPageBreak', false);
+export const avoidPageBreak$ = writableBooleanLocalStorageSubject(presetStorage)(
+  'avoidPageBreak',
+  false
+);
 
-export const customReadingPointEnabled$ = writableBooleanLocalStorageSubject()(
+export const customReadingPointEnabled$ = writableBooleanLocalStorageSubject(presetStorage)(
   'customReadingPointEnabled',
   false
 );
 
-export const selectionToBookmarkEnabled$ = writableBooleanLocalStorageSubject()(
+export const selectionToBookmarkEnabled$ = writableBooleanLocalStorageSubject(presetStorage)(
   'selectionToBookmarkEnabled',
   false
 );
 
-export const confirmClose$ = writableBooleanLocalStorageSubject()('confirmClose', false);
+export const confirmClose$ = writableBooleanLocalStorageSubject(presetStorage)(
+  'confirmClose',
+  false
+);
 
-export const manualBookmark$ = writableBooleanLocalStorageSubject()('manualBookmark', false);
+export const manualBookmark$ = writableBooleanLocalStorageSubject(presetStorage)(
+  'manualBookmark',
+  false
+);
 
-export const autoBookmark$ = writableBooleanLocalStorageSubject()('autoBookmark', false);
+export const autoBookmark$ = writableBooleanLocalStorageSubject(presetStorage)(
+  'autoBookmark',
+  false
+);
 
-export const pageColumns$ = writableNumberLocalStorageSubject()('pageColumns', 0);
+export const pageColumns$ = writableNumberLocalStorageSubject(presetStorage)('pageColumns', 0);
 
 export const requestPersistentStorage$ = writableBooleanLocalStorageSubject()(
   'requestPersistentStorage',

--- a/apps/web/src/lib/data/window/local-storage.ts
+++ b/apps/web/src/lib/data/window/local-storage.ts
@@ -4,7 +4,9 @@
  * All rights reserved.
  */
 
-class WindowStorage {
+import type { PresetStorage } from './preset-storage';
+
+export class WindowStorage {
   private _store = new Map<string, string>();
 
   setItem(key: string, value: string) {
@@ -23,6 +25,8 @@ class WindowStorage {
     this._store = new Map();
   }
 }
+
+export type LocalStorage = Storage | WindowStorage | PresetStorage;
 
 export const localStorage =
   typeof window === 'undefined' ? new WindowStorage() : window.localStorage;

--- a/apps/web/src/lib/data/window/preset-storage.ts
+++ b/apps/web/src/lib/data/window/preset-storage.ts
@@ -1,0 +1,170 @@
+/**
+ * @license BSD-3-Clause
+ * Copyright (c) 2023, ッツ Reader Authors
+ * All rights reserved.
+ */
+
+import { Subject, BehaviorSubject } from 'rxjs';
+import { localStorage } from './local-storage';
+
+export class PresetStorage {
+  private _preset: string;
+
+  private bookPresets$: BehaviorSubject<Record<string, string>>; // idk how better to avoid cyclic dependency
+
+  public presetChanged: Subject<undefined>;
+
+  /* eslint-disable-next-line @typescript-eslint/default-param-last */
+  constructor(preset: string = 'Global', bookPresets$: BehaviorSubject<Record<string, string>>) {
+    this._preset = preset;
+    this.bookPresets$ = bookPresets$;
+    this.presetChanged = new Subject<undefined>();
+  }
+
+  setItem(key: string, value: string) {
+    const allPresetSettingsValue = localStorage.getItem('presetSettings') ?? '{}';
+    let allPresetSettingsObj;
+    let presetSettings;
+
+    try {
+      allPresetSettingsObj = JSON.parse(allPresetSettingsValue);
+      presetSettings = allPresetSettingsObj[this._preset] ?? {};
+    } catch (error) {
+      allPresetSettingsObj = {};
+      presetSettings = {};
+    }
+
+    presetSettings[key] = value;
+    allPresetSettingsObj[this._preset] = presetSettings;
+    localStorage.setItem('presetSettings', JSON.stringify(allPresetSettingsObj));
+  }
+
+  getItem(key: string) {
+    const allPresetSettingsValue = localStorage.getItem('presetSettings');
+
+    if (allPresetSettingsValue) {
+      try {
+        const allPresetSettingsObj = JSON.parse(allPresetSettingsValue);
+        const presetSettings = allPresetSettingsObj[this._preset];
+        return presetSettings[key];
+      } catch (error) {
+        return undefined;
+      }
+    }
+
+    return undefined;
+  }
+
+  /* eslint-disable no-empty */
+  removeItem(key: string) {
+    const allPresetSettingsValue = localStorage.getItem('presetSettings');
+
+    if (allPresetSettingsValue) {
+      try {
+        const allPresetSettingsObj = JSON.parse(allPresetSettingsValue);
+        const presetSettings = allPresetSettingsObj[this._preset];
+        delete presetSettings[key];
+        localStorage.setItem('presetSettings', JSON.stringify(allPresetSettingsObj));
+      } catch (error) {}
+    }
+  }
+
+  clear() {
+    const allPresetSettingsValue = localStorage.getItem('presetSettings');
+
+    if (allPresetSettingsValue) {
+      try {
+        const allPresetSettingsObj = JSON.parse(allPresetSettingsValue);
+        allPresetSettingsObj[this._preset] = {};
+        localStorage.setItem('presetSettings', JSON.stringify(allPresetSettingsObj));
+      } catch (error) {}
+    }
+  }
+
+  // Helper functions
+  static getPresetList() {
+    const allPresetSettingsValue = localStorage.getItem('presetSettings');
+
+    if (allPresetSettingsValue) {
+      try {
+        const allPresetSettingsObj = JSON.parse(allPresetSettingsValue);
+        return Object.keys(allPresetSettingsObj);
+      } catch (error) {
+        return [];
+      }
+    }
+
+    return [];
+  }
+
+  setPreset(presetName: string) {
+    this._preset = presetName;
+    this.presetChanged.next(undefined);
+  }
+
+  createNew(newPresetName: string) {
+    const allPresetSettingsValue = localStorage.getItem('presetSettings');
+
+    if (allPresetSettingsValue) {
+      try {
+        const allPresetSettingsObj = JSON.parse(allPresetSettingsValue);
+        const refPresetSettings = allPresetSettingsObj[this._preset];
+        allPresetSettingsObj[newPresetName] = structuredClone(refPresetSettings);
+        localStorage.setItem('presetSettings', JSON.stringify(allPresetSettingsObj));
+      } catch (error) {}
+    }
+  }
+
+  rename(newPresetName: string) {
+    const allPresetSettingsValue = localStorage.getItem('presetSettings');
+
+    if (allPresetSettingsValue) {
+      try {
+        const allPresetSettingsObj = JSON.parse(allPresetSettingsValue);
+        allPresetSettingsObj[newPresetName] = allPresetSettingsObj[this._preset];
+        delete allPresetSettingsObj[this._preset];
+        localStorage.setItem('presetSettings', JSON.stringify(allPresetSettingsObj));
+      } catch (error) {}
+    }
+
+    const bookPresets = this.bookPresets$.getValue();
+    const bookPresetKeys = Object.keys(bookPresets);
+
+    for (let index = 0; index < bookPresetKeys.length; index += 1) {
+      const key = bookPresetKeys[index];
+      const value = bookPresets[key];
+      if (value === this._preset) {
+        bookPresets[key] = newPresetName;
+      }
+    }
+
+    this.bookPresets$.next(bookPresets);
+
+    this._preset = newPresetName;
+  }
+
+  delete() {
+    const allPresetSettingsValue = localStorage.getItem('presetSettings');
+
+    if (allPresetSettingsValue) {
+      try {
+        const allPresetSettingsObj = JSON.parse(allPresetSettingsValue);
+        delete allPresetSettingsObj[this._preset];
+        localStorage.setItem('presetSettings', JSON.stringify(allPresetSettingsObj));
+      } catch (error) {}
+    }
+
+    const bookPresets = this.bookPresets$.getValue();
+    const bookPresetKeys = Object.keys(bookPresets);
+
+    for (let index = 0; index < bookPresetKeys.length; index += 1) {
+      const key = bookPresetKeys[index];
+      const value = bookPresets[key];
+      if (value === this._preset) {
+        bookPresets[key] = 'Global';
+      }
+    }
+
+    this.bookPresets$.next(bookPresets);
+  }
+}

--- a/apps/web/src/routes/settings/+page.svelte
+++ b/apps/web/src/routes/settings/+page.svelte
@@ -31,7 +31,8 @@
     swipeThreshold$,
     theme$,
     viewMode$,
-    writingMode$
+    writingMode$,
+    database
   } from '$lib/data/store';
   import { mergeEntries } from '$lib/components/merged-header-icon/merged-entries';
   import { pagePath } from '$lib/data/env';
@@ -39,6 +40,7 @@
   import { formatPageTitle } from '$lib/functions/format-page-title';
   import { writableSubject } from '$lib/functions/svelte/store';
   import { reduceToEmptyString } from '$lib/functions/rxjs/reduce-to-empty-string';
+  import { map, share } from 'rxjs';
 
   const persistentStorage$ = writableSubject(false);
   let persistentStorageReactive = false;
@@ -75,6 +77,11 @@
     persistentStorage$.next(value);
     persistentStorageReactive = true;
   }
+
+  const currentBookId$ = database.lastItem$.pipe(
+    map((item) => item?.dataId),
+    share()
+  );
 </script>
 
 <svelte:head>
@@ -89,6 +96,7 @@
   <div class="max-w-5xl">
     <SettingsContent
       {activeSettings}
+      bookId={$currentBookId$ ?? 0}
       bind:selectedTheme={$theme$}
       bind:fontFamilyGroupOne={$fontFamilyGroupOne$}
       bind:fontFamilyGroupTwo={$fontFamilyGroupTwo$}


### PR DESCRIPTION
## Preset Feature
https://github.com/ttu-ttu/ebook-reader/assets/57080387/7363fa9f-03e1-45d4-ba59-507cdf7e128b

Gives readers the ability to have different presets for their settings and apply the presets to different books.

Disclaimer: I don't know Svelte and only spent a few hours creating this, so the code could probably be made a million times better

## Features Added
- ### Preset Selector
![006b440233d724984c880b51a489b9f2](https://github.com/ttu-ttu/ebook-reader/assets/57080387/00245a5f-d417-45ff-974f-1571fc90f754)
Selecting a preset from the list of available presets applies the preset's settings onto the current book. Any changes made to the preset's settings will also affect other books using the same preset. The `Global` preset is the default preset for loaded books and cannot be renamed nor deleted.

- ### Create Preset
![a3b9ff06e6592c8075d8ee2ae58b3c34](https://github.com/ttu-ttu/ebook-reader/assets/57080387/61ab2291-53e3-40f1-9530-3f93b594c7ab)
Creates a new Preset with the specified name. Duplicate names are not allowed. The newly created preset is initialized by cloning the currently selected preset.

- ### Rename Preset
![b0d18c461ce566ad7ac83ee27463cc0b](https://github.com/ttu-ttu/ebook-reader/assets/57080387/7a1466d4-d413-4949-b260-1b8cd58a7fd7)
Renames the preset. Cannot rename the default preset `Global`.

- ### Delete Preset
![5965265fdf856314e8f44103eb493f2e](https://github.com/ttu-ttu/ebook-reader/assets/57080387/c5ce7b67-653c-40c5-b1ab-c911380274a4)
Deletes the preset. Cannot delete the default preset `Global`.
