### PR TITLE
Set Manifest `display` to `fullscreen`

### DIFF
--- a/apps/web/static/manifest.webmanifest
+++ b/apps/web/static/manifest.webmanifest
@@ -3,7 +3,7 @@
   "short_name": "Reader",
   "theme_color": "#37474f",
   "background_color": "#f5f5f6",
-  "display": "standalone",
+  "display": "fullscreen",
   "scope": "./",
   "start_url": "./",
   "icons": [


### PR DESCRIPTION
I was finding the existence of the status bar very annoying while using the PWA due to the difference in color to the page background, and I think most people would prefer not to have it in the way while reading.

Did test and it works.