### PR TITLE
fix: preserve classes on <html> and <body> tags in EPUBs

### DIFF
--- a/apps/web/src/lib/functions/file-loaders/epub/generate-epub-html.ts
+++ b/apps/web/src/lib/functions/file-loaders/epub/generate-epub-html.ts
@@ -139,14 +139,22 @@ export default function generateEpubHtml(
       htmlHref = itemIdToHtmlRef[itemIdRef];
     }
 
-    const parsedContent = parser.parseFromString(data[htmlHref] as string, 'text/html');
+    let parsedContent = parser.parseFromString(data[htmlHref] as string, 'text/html');
+    let body = parsedContent.body;
+
+    if (!body?.childElementCount) {
+      parsedContent = parser.parseFromString(data[htmlHref] as string, 'text/xml');
+      body = parsedContent.querySelector('body'); // XMLDocument doesn't seem to have the body property
+
+      if (!body?.childElementCount) {
+        throw new Error('Unable to find body tag while parsing EPUB content');
+      }
+    }
 
     const htmlClass = parsedContent.querySelector('html')?.className || '';
-
-    const body = parsedContent.body;
-    const bodyId = body?.id || '';
-    const bodyClass = body?.className || '';
-    let innerHtml = body?.innerHTML || '';
+    const bodyId = body.id || '';
+    const bodyClass = body.className || '';
+    let innerHtml = body.innerHTML || '';
 
     blobLocations.forEach((blobLocation) => {
       innerHtml = innerHtml.replaceAll(

--- a/apps/web/src/lib/functions/file-loaders/epub/generate-epub-html.ts
+++ b/apps/web/src/lib/functions/file-loaders/epub/generate-epub-html.ts
@@ -139,12 +139,11 @@ export default function generateEpubHtml(
       htmlHref = itemIdToHtmlRef[itemIdRef];
     }
 
-    const contentParser = new DOMParser();
-    const parsedContent = contentParser.parseFromString(data[htmlHref] as string, 'text/html');
+    const parsedContent = parser.parseFromString(data[htmlHref] as string, 'text/html');
 
     const htmlClass = parsedContent.querySelector('html')?.className || '';
 
-    const body = parsedContent.querySelector('body');
+    const body = parsedContent.body;
     const bodyId = body?.id || '';
     const bodyClass = body?.className || '';
     let innerHtml = body?.innerHTML || '';

--- a/apps/web/src/lib/functions/file-loaders/epub/generate-epub-html.ts
+++ b/apps/web/src/lib/functions/file-loaders/epub/generate-epub-html.ts
@@ -147,7 +147,7 @@ export default function generateEpubHtml(
       body = parsedContent.querySelector('body'); // XMLDocument doesn't seem to have the body property
 
       if (!body?.childNodes?.length) {
-        throw new Error('Unable to find body tag while parsing EPUB content');
+        throw new Error('Unable to find valid body content while parsing EPUB');
       }
     }
 

--- a/apps/web/src/lib/functions/file-loaders/epub/generate-epub-html.ts
+++ b/apps/web/src/lib/functions/file-loaders/epub/generate-epub-html.ts
@@ -156,14 +156,14 @@ export default function generateEpubHtml(
     });
 
     const childBodyDiv = document.createElement('div');
-    childBodyDiv.className = bodyClass;
+    childBodyDiv.className = `ttu-book-body-wrapper ${bodyClass}`;
     if (bodyId) {
       childBodyDiv.id = bodyId;
     }
     childBodyDiv.innerHTML = innerHtml;
 
     const childHtmlDiv = document.createElement('div');
-    childHtmlDiv.className = htmlClass;
+    childHtmlDiv.className = `ttu-book-html-wrapper ${htmlClass}`;
     childHtmlDiv.appendChild(childBodyDiv);
 
     const childWrapperDiv = document.createElement('div');

--- a/apps/web/src/lib/functions/file-loaders/epub/generate-epub-html.ts
+++ b/apps/web/src/lib/functions/file-loaders/epub/generate-epub-html.ts
@@ -142,11 +142,11 @@ export default function generateEpubHtml(
     let parsedContent = parser.parseFromString(data[htmlHref] as string, 'text/html');
     let body = parsedContent.body;
 
-    if (!body?.childElementCount) {
+    if (!body?.childNodes?.length) {
       parsedContent = parser.parseFromString(data[htmlHref] as string, 'text/xml');
       body = parsedContent.querySelector('body'); // XMLDocument doesn't seem to have the body property
 
-      if (!body?.childElementCount) {
+      if (!body?.childNodes?.length) {
         throw new Error('Unable to find body tag while parsing EPUB content');
       }
     }


### PR DESCRIPTION
Currently, the `<html>` and `<body>` tags in EPUB content are discarded (aside from the `id` attribute of the `<body>` tag). I'm encountering EPUBs that have classes on these tags, and use those classes in CSS rules:

item/xhtml/p-002.xhtml:
```html
<html
 xmlns="http://www.w3.org/1999/xhtml"
 xmlns:epub="http://www.idpf.org/2007/ops"
 xml:lang="ja"
 class="vrtl"
>
<body class="p-text">
<div class="main">
...
```

item/style/style-standard.css:
```css
.hltr .start-4em   { margin-left:  4.00em; }
.vrtl .start-4em   { margin-top:  4.00em; }
```

This patch creates wrapper divs that duplicate the `class` attributes of the `<html>` and `<body>` tags to make sure EPUB stylesheets function as expected.