### PR TITLE
feat: add system fonts and change language tag

### DIFF
--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="writing-horizontal-tb h-full w-full" lang="en">
+<html class="writing-horizontal-tb h-full w-full" lang="ja">
   <head>
     <meta charset="utf-8" />
     <meta

--- a/apps/web/src/lib/components/settings/settings-content.svelte
+++ b/apps/web/src/lib/components/settings/settings-content.svelte
@@ -435,8 +435,9 @@
       <div slot="header" class="flex items-center">
         <SettingsFontSelector
           availableFonts={[
-            LocalFont.BIZUDMINCHO,
+            LocalFont.SERIF,
             LocalFont.NOTOSERIFJP,
+            LocalFont.BIZUDMINCHO,
             LocalFont.GENEI,
             LocalFont.KLEEONE,
             LocalFont.KLEEONESEMIBOLD,
@@ -465,14 +466,14 @@
       <input
         type="text"
         class={inputClasses}
-        placeholder="Noto Serif JP"
+        placeholder="Serif"
         bind:value={fontFamilyGroupOne}
       />
     </SettingsItemGroup>
     <SettingsItemGroup title="Font family (Group 2)">
       <div slot="header" class="flex items-center">
         <SettingsFontSelector
-          availableFonts={[LocalFont.BIZUDGOTHIC, LocalFont.NOTOSANSJP]}
+          availableFonts={[LocalFont.SANSSERIF,  LocalFont.NOTOSANSJP, LocalFont.BIZUDGOTHIC]}
           bind:fontValue={fontFamilyGroupTwo}
         />
         {#if fontCacheSupported}
@@ -495,7 +496,7 @@
       <input
         type="text"
         class={inputClasses}
-        placeholder="Noto Sans JP"
+        placeholder="Sans-Serif"
         bind:value={fontFamilyGroupTwo}
       />
     </SettingsItemGroup>

--- a/apps/web/src/lib/data/fonts.ts
+++ b/apps/web/src/lib/data/fonts.ts
@@ -12,7 +12,9 @@ export enum LocalFont {
   KLEEONESEMIBOLD = 'Klee One SemiBold',
   NOTOSANSJP = 'Noto Sans JP',
   NOTOSERIFJP = 'Noto Serif JP',
-  SHIPPORIMINCHO = 'Shippori Mincho'
+  SHIPPORIMINCHO = 'Shippori Mincho',
+  SERIF = "Serif",
+  SANSSERIF = "Sans-Serif"
 }
 
 export interface UserFont {
@@ -31,7 +33,9 @@ export const reservedFontNames = new Set([
   'Klee One SemiBold',
   'Noto Sans JP',
   'Noto Serif JP',
-  'Shippori Mincho'
+  'Shippori Mincho',
+  'Serif',
+  'Sans-Serif'
 ]);
 
 export function isStoredFont(fontName: string, userFonts: UserFont[]) {

--- a/apps/web/src/lib/data/fonts.ts
+++ b/apps/web/src/lib/data/fonts.ts
@@ -13,8 +13,8 @@ export enum LocalFont {
   NOTOSANSJP = 'Noto Sans JP',
   NOTOSERIFJP = 'Noto Serif JP',
   SHIPPORIMINCHO = 'Shippori Mincho',
-  SERIF = "Serif",
-  SANSSERIF = "Sans-Serif"
+  SERIF = 'Serif',
+  SANSSERIF = 'Sans-Serif'
 }
 
 export interface UserFont {

--- a/apps/web/src/lib/functions/book-data-loader/format-style-sheet.ts
+++ b/apps/web/src/lib/functions/book-data-loader/format-style-sheet.ts
@@ -94,9 +94,9 @@ function convertFontFamily(declaration: Declaration) {
   if (declaration.property === 'font-family') {
     let newValue: string = declaration.value;
     if (newValue.includes('sans-serif')) {
-      newValue = `var(--font-family-sans-serif, Noto Sans JP, sans-serif)`;
+      newValue = `var(--font-family-sans-serif, sans-serif)`;
     } else if (newValue.includes('serif')) {
-      newValue = `var(--font-family-serif, Noto Serif JP, serif)`;
+      newValue = `var(--font-family-serif, serif)`;
     }
     return {
       key: declaration.property,


### PR DESCRIPTION
Changes language tag from English to Japanese to make sure symbols are rendered correctly for fonts that don't have full coverage. This also fixes an issue with fallback fonts being rendered incorrectly and incorrect system fonts being chosen by the browser.

In addition to this, the default font when the font-family fields are empty has been changed to the default serif and sans-serif  fonts of the user's device. These fonts have also been added to the font menu to make it easy for the user to choose their device's system fonts.