### PR TITLE
fix: chrome scrollbar colors

### DIFF
--- a/apps/web/src/app.scss
+++ b/apps/web/src/app.scss
@@ -7,6 +7,7 @@
 :root {
   --font-color: rgba(0, 0, 0, 0.87);
   --background-color: #eceff1;
+  scrollbar-color: #c1c1c1 #c1c1c100;
 }
 
 @layer base {


### PR DESCRIPTION
Makes scrollbar background color transparent to universally match user themes for browsers that don't already do so (e.g. Chrome)