### PR TITLE
fix: chrome cover rendering

### DIFF
--- a/apps/web/src/app.scss
+++ b/apps/web/src/app.scss
@@ -10,6 +10,10 @@
   scrollbar-color: #c1c1c1 #c1c1c100;
 }
 
+.book-cover {
+  overflow-clip-margin: unset;
+}
+
 @layer base {
   body {
     color: var(--font-color);

--- a/apps/web/src/lib/components/book-card/book-card.svelte
+++ b/apps/web/src/lib/components/book-card/book-card.svelte
@@ -77,7 +77,7 @@
           decoding="async"
           loading="lazy"
           referrerpolicy="no-referrer"
-          class="relative h-full w-full object-cover transition delay-150 duration-700 ease-out"
+          class="book-cover relative h-full w-full object-cover transition delay-150 duration-700 ease-out"
           class:blur={!imageLoadComplete}
           src={mapImagePath(imagePath)}
           {alt}


### PR DESCRIPTION
Fixes a rendering issue of the book covers that occurs due to a bug in chrome that causes images that use "object-fit: cover" to become pixelated. 