### PR TITLE
fix: remove paginated padding

### DIFF
--- a/apps/web/src/lib/components/book-reader/book-reader-paginated/book-reader-paginated.svelte
+++ b/apps/web/src/lib/components/book-reader/book-reader-paginated/book-reader-paginated.svelte
@@ -789,29 +789,5 @@
       width: 100%;
       height: auto;
     }
-
-    :global(.book-content-container > *:not(.ttu-book-html-wrapper) > *:has(ruby):has(rt)),
-    :global(
-      .book-content-container
-        > div.ttu-book-html-wrapper
-        > div.ttu-book-body-wrapper
-        > *
-        > *:has(ruby):has(rt)
-    ) {
-      padding-right: 10px !important;
-    }
-  }
-
-  .book-content--writing-horizontal-rl {
-    :global(.book-content-container > *:not(.ttu-book-html-wrapper) > *:has(ruby):has(rt)),
-    :global(
-      .book-content-container
-        > div.ttu-book-html-wrapper
-        > div.ttu-book-body-wrapper
-        > *
-        > *:has(ruby):has(rt)
-    ) {
-      padding-top: 10px !important;
-    }
   }
 </style>


### PR DESCRIPTION
In paginated mode, there is extra padding added to any lines that have furigana. Browsers automatically add padding for furigana if it's needed so this pr removes the unnecessary extra padding.