### PR TITLE
fix: remove padding and change ruby behavior

### DIFF
--- a/apps/web/src/lib/components/book-reader/book-reader-paginated/book-reader-paginated.svelte
+++ b/apps/web/src/lib/components/book-reader/book-reader-paginated/book-reader-paginated.svelte
@@ -789,29 +789,5 @@
       width: 100%;
       height: auto;
     }
-
-    :global(.book-content-container > *:not(.ttu-book-html-wrapper) > *:has(ruby):has(rt)),
-    :global(
-      .book-content-container
-        > div.ttu-book-html-wrapper
-        > div.ttu-book-body-wrapper
-        > *
-        > *:has(ruby):has(rt)
-    ) {
-      padding-right: 10px !important;
-    }
-  }
-
-  .book-content--writing-horizontal-rl {
-    :global(.book-content-container > *:not(.ttu-book-html-wrapper) > *:has(ruby):has(rt)),
-    :global(
-      .book-content-container
-        > div.ttu-book-html-wrapper
-        > div.ttu-book-body-wrapper
-        > *
-        > *:has(ruby):has(rt)
-    ) {
-      padding-top: 10px !important;
-    }
   }
 </style>

--- a/apps/web/src/lib/components/book-reader/book-reader-paginated/book-reader-paginated.svelte
+++ b/apps/web/src/lib/components/book-reader/book-reader-paginated/book-reader-paginated.svelte
@@ -789,5 +789,29 @@
       width: 100%;
       height: auto;
     }
+
+    :global(.book-content-container > *:not(.ttu-book-html-wrapper) > *:has(ruby):has(rt)),
+    :global(
+      .book-content-container
+        > div.ttu-book-html-wrapper
+        > div.ttu-book-body-wrapper
+        > *
+        > *:has(ruby):has(rt)
+    ) {
+      overflow: hidden;
+    }
+  }
+
+  .book-content--writing-horizontal-rl {
+    :global(.book-content-container > *:not(.ttu-book-html-wrapper) > *:has(ruby):has(rt)),
+    :global(
+      .book-content-container
+        > div.ttu-book-html-wrapper
+        > div.ttu-book-body-wrapper
+        > *
+        > *:has(ruby):has(rt)
+    ) {
+      overflow: hidden;
+    }
   }
 </style>

--- a/apps/web/src/lib/components/book-reader/styles.scss
+++ b/apps/web/src/lib/components/book-reader/styles.scss
@@ -28,6 +28,10 @@
     user-select: none;
   }
 
+  :global(ruby) {
+    line-height: 1;
+  }
+
   :global([data-ttu-spoiler-img]) {
     :global(.spoiler-label) {
       display: none;


### PR DESCRIPTION
This PR removes the padding added to lines that have furigana and instead, changes have been made to ruby text to address the issue referenced in yomidevs/yomitan/issues/855. Some more testing may be needed but I haven't encountered any problems using Chrome/Firefox (Windows).