### PR TITLE
feat: separate character counter and percentage

### DIFF
--- a/apps/web/src/lib/components/log-report-dialog.svelte
+++ b/apps/web/src/lib/components/log-report-dialog.svelte
@@ -67,6 +67,7 @@
     isOnline$,
     multiplier$,
     showCharacterCounter$,
+    showPercentage$,
     enableReaderWakeLock$
   } from '$lib/data/store';
 
@@ -106,6 +107,7 @@
           enableTextWrapPretty: enableTextWrapPretty$.getValue(),
           enableReaderWakeLock: enableReaderWakeLock$.getValue(),
           showCharacterCounter$: showCharacterCounter$.getValue(),
+          showPercentage$: showPercentage$.getValue(),
           confirmClose: confirmClose$.getValue(),
           autoBookmark: autoBookmark$.getValue(),
           autoBookmarkTime: autoBookmarkTime$.getValue(),

--- a/apps/web/src/lib/components/settings/settings-content.svelte
+++ b/apps/web/src/lib/components/settings/settings-content.svelte
@@ -92,6 +92,8 @@
 
   export let showCharacterCounter: boolean;
 
+  export let showPercentage: boolean;
+
   export let secondDimensionMaxValue: number;
 
   export let firstDimensionMargin: number;
@@ -707,6 +709,9 @@
     {/if}
     <SettingsItemGroup title="Show Character Counter">
       <ButtonToggleGroup options={optionsForToggle} bind:selectedOptionId={showCharacterCounter} />
+    </SettingsItemGroup>
+    <SettingsItemGroup title="Show Percentage">
+      <ButtonToggleGroup options={optionsForToggle} bind:selectedOptionId={showPercentage} />
     </SettingsItemGroup>
     <SettingsItemGroup title="Disable Wheel Navigation">
       <ButtonToggleGroup

--- a/apps/web/src/lib/data/store.ts
+++ b/apps/web/src/lib/data/store.ts
@@ -116,6 +116,10 @@ export const showCharacterCounter$ = writableBooleanLocalStorageSubject()(
   'showCharacterCounter',
   true
 );
+export const showPercentage$ = writableBooleanLocalStorageSubject()(
+  'showPercentage',
+  true
+);
 export const viewMode$ = writableStringLocalStorageSubject<ViewMode>()(
   'viewMode',
   ViewMode.Paginated

--- a/apps/web/src/routes/b/+page.svelte
+++ b/apps/web/src/routes/b/+page.svelte
@@ -85,7 +85,8 @@
     readingGoalsMergeMode$,
     pauseTrackerOnCustomPointChange$,
     hideSpoilerImageMode$,
-    showCharacterCounter$
+    showCharacterCounter$,
+    showPercentage$
   } from '$lib/data/store';
   import BookCompletionConfetti from '$lib/components/book-reader/book-completion-confetti/book-completion-confetti.svelte';
   import BookReaderHeader from '$lib/components/book-reader/book-reader-header.svelte';
@@ -1775,19 +1776,19 @@
     {/if}
   </div>
   {#if showFooter && bookCharCount}
-    {@const currentProgress = `${exploredCharCount} / ${bookCharCount} ${(
-      (exploredCharCount / bookCharCount) *
-      100
-    ).toFixed(2)}%`}
+    {@const currentProgress = [
+      $showCharacterCounter$ ? `${exploredCharCount} / ${bookCharCount}` : '',
+      $showPercentage$ ? `${((exploredCharCount / bookCharCount) * 100).toFixed(2)}%` : ''
+    ].filter(Boolean).join(' ')}
     <div
       tabindex="0"
       role="button"
       title="Click to copy Progress"
       class="writing-horizontal-tb fixed bottom-2 right-2 z-10 text-xs leading-none select-none"
-      class:invisible={!$showCharacterCounter$}
+      class:invisible={!$showCharacterCounter$ && !$showPercentage$}
       style:color={$themeOption$?.tooltipTextFontColor}
       on:click|stopPropagation={({ target }) => {
-        if (!$showCharacterCounter$) {
+        if (!$showCharacterCounter$ && !$showPercentage$) {
           return;
         }
 

--- a/apps/web/src/routes/settings/+page.svelte
+++ b/apps/web/src/routes/settings/+page.svelte
@@ -40,6 +40,7 @@
     secondDimensionMaxValue$,
     selectionToBookmarkEnabled$,
     showCharacterCounter$,
+    showPercentage$,
     showExternalPlaceholder$,
     startDayHoursForTracker$,
     statisticsEnabled$,
@@ -157,6 +158,7 @@
       bind:textMarginMode={$textMarginMode$}
       bind:enableReaderWakeLock={$enableReaderWakeLock$}
       bind:showCharacterCounter={$showCharacterCounter$}
+      bind:showPercentage={$showPercentage$}
       bind:viewMode={$viewMode$}
       bind:secondDimensionMaxValue={$secondDimensionMaxValue$}
       bind:firstDimensionMargin={$firstDimensionMargin$}


### PR DESCRIPTION
Adds separate options enable/disable the character counter and the progress percentage.
I couldn't find a good way to check progress when having the character counter disabled currently.