### PR TITLE
Minor enhancement to reader

### DIFF
--- a/apps/web/src/routes/b/+page.svelte
+++ b/apps/web/src/routes/b/+page.svelte
@@ -1860,7 +1860,7 @@
           return;
         }
 
-        copyCurrentProgress($sectionData$?.length ? fullProgress : currentProgress);
+        copyCurrentProgress(fullProgress);
 
         if (target instanceof HTMLElement) {
           pulseElement(target, 'add', 0.5, 500);
@@ -1868,7 +1868,7 @@
       }}
       on:keyup={dummyFn}
     >
-      {$sectionData$?.length ? fullProgress : currentProgress}
+      {fullProgress}
     </div>
   {/if}
 </div>


### PR DESCRIPTION
Currently, you need to open the TOC each time you want to check the chapter progress.
This commit adds the chapter progress percentage to the center of the footer.

This was requested by a friend who reads with the app often.

@Renji-XD I'm hoping you can merge it since it's a very minor enhancement. 
Please let me know if anything needs to be changed or fixed and I'll do so.