### PR TITLE
feat: apply chosen theme to menu portions of the reader

### DIFF
--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -8,6 +8,8 @@
   import { fontFamilyGroupOne$, isOnline$, userFonts$ } from '$lib/data/store';
   import { dummyFn, isMobile, isMobile$ } from '$lib/functions/utils';
   import { MetaTags } from 'svelte-meta-tags';
+  import { theme$, customThemes$ } from '$lib/data/store';
+  import { availableThemes } from '$lib/data/theme-option';
   import '../app.scss';
 
   let path = '';
@@ -67,6 +69,15 @@
       styleElement.appendChild(textNode);
       document.head.append(styleElement);
     }
+  }
+
+  $: currentThemeData = availableThemes.get($theme$) || $customThemes$[$theme$];
+
+  $: if (browser && currentThemeData) {
+    const root = document.documentElement;
+    // Apply the colors as CSS variables
+    root.style.setProperty('--global-bg', currentThemeData.backgroundColor);
+    root.style.setProperty('--global-text', currentThemeData.fontColor);
   }
 
   function closeAllDialogs() {
@@ -135,3 +146,74 @@
 <span style={`font-family: ${$fontFamilyGroupOne$ || 'Noto Serif JP'}`} />
 
 <DomainHint />
+
+<style>
+  /* apply selected theme globally */
+  :global(body) {
+    background-color: var(--global-bg);
+    color: var(--global-text);
+    transition:
+      background-color 0.2s ease,
+      color 0.2s ease;
+  }
+  :global(#app),
+  :global(.bg-white),
+  :global(.bg-gray-100) {
+    background-color: var(--global-bg);
+    color: var(--global-text);
+  }
+
+  /* reset the color of buttons so the theme options are unaffected */
+  :global(.toggle-option-button) {
+    background-color: initial;
+    color: initial;
+  }
+  :global(.toggle-option-button *) {
+    background-color: transparent !important;
+    color: inherit !important;
+  }
+
+  /* text input fields, making the box background a little darker or lighter for visibility
+  depending on light or dark theme */
+  :global(input),
+  :global(select),
+  :global(textarea) {
+    background-color: var(--global-bg) !important;
+    color: var(--global-text);
+
+    background-image:
+      linear-gradient(rgba(0, 0, 0, 0.07), rgba(0, 0, 0, 0.07)),
+      linear-gradient(rgba(255, 255, 255, 0.1), rgba(255, 255, 255, 0.15));
+
+    /* border for text input */
+    border: 1px solid var(--global-text) !important;
+    border-radius: 4px;
+    padding: 4px;
+  }
+
+  /* heatmap sidebar */
+  :global(.sticky.left-0),
+  :global(.text-xs.md\:text-sm) {
+    background-color: var(--global-bg);
+    color: var(--global-text);
+  }
+
+  :global(div[style*='--background-color']) {
+    --background-color: var(--global-bg);
+    background-color: var(--global-bg);
+    color: var(--global-text);
+  }
+
+  /* Blank tiles in heatmap inherit theme text color at low opacity */
+  :global(.bg-slate-200),
+  :global(.bg-slate-300) {
+    background-color: var(--global-text);
+    opacity: 0.15;
+    border: 1px solid var(--global-bg) !important;
+  }
+
+  /* Active data tiles show actual color */
+  :global(div[data-date][style*='background-color']) {
+    opacity: 1;
+  }
+</style>


### PR DESCRIPTION
This PR addresses #454 and #363 by reactively getting theme data from the store whenever the user changes the theme, mapping them to css variables in `layout.svelte` and applies the background and text color globally. I also made some tweaks to make UI elements like the text fields and the statistics heatmap elements color adaptively from the background color to appear more visible whether shown in a light or dark theme.

Might need more testing to ensure it works for all custom user themes, and also that all statistics data shows correctly (provided a more dense heatmap than my own)

Quick before and after from light-theme to gray-theme
<img width="1893" height="1028" alt="image" src="https://github.com/user-attachments/assets/e3d68afb-e4dd-4088-ad7b-0a3a91ae2cde" />
<img width="1914" height="1040" alt="image" src="https://github.com/user-attachments/assets/183ac1ee-43a6-4e34-b6f3-05699135c11e" />

And also addressing the colors of empty tiles and sticky sidebar labels of the statistics review heatmap:
<img width="1253" height="429" alt="image" src="https://github.com/user-attachments/assets/85d8b50d-7c1e-4f2e-a5e3-d4d952ca9d02" />
<img width="1321" height="434" alt="image" src="https://github.com/user-attachments/assets/f29db384-0af9-4550-ac98-7cb8f0be47b9" />
