### PR TITLE
feat: add opt-in text labels for header icon buttons (#487)

### DIFF
--- a/apps/web/src/lib/components/book-card/book-manager-header.svelte
+++ b/apps/web/src/lib/components/book-card/book-manager-header.svelte
@@ -7,6 +7,7 @@
   import {
     baseHeaderClasses,
     baseIconClasses,
+    labelIconClasses,
     nTranslateXHeaderFa,
     pHeaderFa,
     pxScreen,
@@ -28,7 +29,8 @@
     fsStorageSource$,
     gDriveStorageSource$,
     isOnline$,
-    oneDriveStorageSource$
+    oneDriveStorageSource$,
+    showHeaderLabels$
   } from '$lib/data/store';
   import { inputAllowDirectory } from '$lib/functions/file-dom/input-allow-directory';
   import { inputFile } from '$lib/functions/file-dom/input-file';
@@ -97,6 +99,8 @@
   let countImportElm: HTMLInputElement;
   let storageSourceElm: Popover;
   let sortOptionsElm: Popover;
+  $: iconClasses = $showHeaderLabels$ ? labelIconClasses : baseIconClasses;
+
   let isOldUrl = false;
   let showLoadCount = false;
 
@@ -245,22 +249,27 @@
           in:scale={inAnimationParams}
           out:scale={outAnimationParams}
         >
-          <svg
+          <div
             tabindex="0"
             role="button"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
+            class={iconClasses}
             class:opacity-100={selectMode}
             class:opacity-60={!selectMode}
-            class={baseIconClasses}
             on:click={() => (selectMode = hasBooks && !selectMode)}
             on:keyup={dummyFn}
           >
-            <path
-              class="fill-current"
-              d="M20,4v12H8V4H20 M20,2H8C6.9,2,6,2.9,6,4v12c0,1.1,0.9,2,2,2h12c1.1,0,2-0.9,2-2V4C22,2.9,21.1,2,20,2L20,2z M12.47,14 L9,10.5l1.4-1.41l2.07,2.08L17.6,6L19,7.41L12.47,14z M4,6H2v14c0,1.1,0.9,2,2,2h14v-2H4V6z"
-            />
-          </svg>
+            <svg
+              viewBox="0 0 24 24"
+              xmlns="http://www.w3.org/2000/svg"
+              class={$showHeaderLabels$ ? 'h-3.5 w-3.5 xl:h-3 xl:w-3' : 'h-full w-full'}
+            >
+              <path
+                class="fill-current"
+                d="M20,4v12H8V4H20 M20,2H8C6.9,2,6,2.9,6,4v12c0,1.1,0.9,2,2,2h12c1.1,0,2-0.9,2-2V4C22,2.9,21.1,2,20,2L20,2z M12.47,14 L9,10.5l1.4-1.41l2.07,2.08L17.6,6L19,7.41L12.47,14z M4,6H2v14c0,1.1,0.9,2,2,2h14v-2H4V6z"
+              />
+            </svg>
+            {#if $showHeaderLabels$}<span>Select</span>{/if}
+          </div>
         </div>
       {:else}
         <div
@@ -289,43 +298,51 @@
       <div class="absolute left-1/2 h-full -translate-x-1/2 transform-gpu">
         {#if !selectMode}
           {#if hasBookOpened}
-            <div title="Back to Book">
+            <div
+              tabindex="0"
+              role="button"
+              title="Back to Book"
+              class={iconClasses}
+              in:scale={inAnimationParams}
+              out:scale={outAnimationParams}
+              on:click={() => dispatch('backToBookClick')}
+              on:keyup={dummyFn}
+            >
               <svg
-                tabindex="0"
-                role="button"
                 xmlns="http://www.w3.org/2000/svg"
                 viewBox="0 0 24 24"
-                class={baseIconClasses}
-                in:scale={inAnimationParams}
-                out:scale={outAnimationParams}
-                on:click={() => dispatch('backToBookClick')}
-                on:keyup={dummyFn}
+                class={$showHeaderLabels$ ? 'h-3.5 w-3.5 xl:h-3 xl:w-3' : 'h-full w-full'}
               >
                 <path
                   class="fill-current"
                   d="M21 5c-1.11-.35-2.33-.5-3.5-.5-1.95 0-4.05.4-5.5 1.5-1.45-1.1-3.55-1.5-5.5-1.5S2.45 4.9 1 6v14.65c0 .25.25.5.5.5.1 0 .15-.05.25-.05C3.1 20.45 5.05 20 6.5 20c1.95 0 4.05.4 5.5 1.5 1.35-.85 3.8-1.5 5.5-1.5 1.65 0 3.35.3 4.75 1.05.1.05.15.05.25.05.25 0 .5-.25.5-.5V6c-.6-.45-1.25-.75-2-1zm0 13.5c-1.1-.35-2.3-.5-3.5-.5-1.7 0-4.15.65-5.5 1.5V8c1.35-.85 3.8-1.5 5.5-1.5 1.2 0 2.4.15 3.5.5v11.5zm-3.5-8c.88 0 1.73.09 2.5.26V9.24c-.79-.15-1.64-.24-2.5-.24-1.7 0-3.24.29-4.5.83v1.66c1.13-.64 2.7-.99 4.5-.99zM13 12.49v1.66c1.13-.64 2.7-.99 4.5-.99.88 0 1.73.09 2.5.26V11.9c-.79-.15-1.64-.24-2.5-.24-1.7 0-3.24.3-4.5.83zm4.5 1.84c-1.7 0-3.24.29-4.5.83v1.66c1.13-.64 2.7-.99 4.5-.99.88 0 1.73.09 2.5.26v-1.52c-.79-.16-1.64-.24-2.5-.24z"
                 />
               </svg>
+              {#if $showHeaderLabels$}<span>Book</span>{/if}
             </div>
           {/if}
         {:else}
-          <div title="Select all Books">
+          <div
+            tabindex="0"
+            role="button"
+            title="Select all Books"
+            class={iconClasses}
+            in:scale={inAnimationParams}
+            out:scale={outAnimationParams}
+            on:click={() => dispatch('selectAllClick')}
+            on:keyup={dummyFn}
+          >
             <svg
-              tabindex="0"
-              role="button"
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 24 24"
-              class={baseIconClasses}
-              in:scale={inAnimationParams}
-              out:scale={outAnimationParams}
-              on:click={() => dispatch('selectAllClick')}
-              on:keyup={dummyFn}
+              class={$showHeaderLabels$ ? 'h-3.5 w-3.5 xl:h-3 xl:w-3' : 'h-full w-full'}
             >
               <path
                 class="fill-current"
                 d="M18 7l-1.41-1.41-6.34 6.34 1.41 1.41L18 7zm4.24-1.41L11.66 16.17 7.48 12l-1.41 1.41L11.66 19l12-12-1.42-1.41zM.41 13.41L6 19l1.41-1.41L1.83 12 .41 13.41z"
               />
             </svg>
+            {#if $showHeaderLabels$}<span>All</span>{/if}
           </div>
         {/if}
       </div>
@@ -357,13 +374,16 @@
             >
               <div slot="icon">
                 {#key $storageIcon$}
-                  <svg
-                    class={baseIconClasses}
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox={$storageIcon$.viewBox}
-                  >
-                    <path class="fill-current" d={$storageIcon$.d} />
-                  </svg>
+                  <div class={iconClasses}>
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox={$storageIcon$.viewBox}
+                      class={$showHeaderLabels$ ? 'h-3.5 w-3.5 xl:h-3 xl:w-3' : 'h-full w-full'}
+                    >
+                      <path class="fill-current" d={$storageIcon$.d} />
+                    </svg>
+                    {#if $showHeaderLabels$}<span>Storage Source</span>{/if}
+                  </div>
                 {/key}
               </div>
               <div class="w-28 bg-gray-700" slot="content">
@@ -410,12 +430,19 @@
               yOffset={0}
               bind:this={sortOptionsElm}
             >
-              <div slot="icon" class={baseIconClasses} title="Select Sort Options">
+              <div slot="icon" class={iconClasses} title="Select Sort Options">
                 {#if $booklistSortOptions$[$storageSource$].direction === SortDirection.ASC}
-                  <Fa icon={faArrowDownShortWide} />
+                  <Fa
+                    icon={faArrowDownShortWide}
+                    class={$showHeaderLabels$ ? 'text-sm xl:text-xs' : ''}
+                  />
                 {:else}
-                  <Fa icon={faArrowDownWideShort} />
+                  <Fa
+                    icon={faArrowDownWideShort}
+                    class={$showHeaderLabels$ ? 'text-sm xl:text-xs' : ''}
+                  />
                 {/if}
+                {#if $showHeaderLabels$}<span>Sort</span>{/if}
               </div>
               <div class="w-44 bg-gray-700" slot="content">
                 {#each sortMenuItems as sortMenuItem (sortMenuItem.property)}
@@ -508,51 +535,55 @@
             tabindex="0"
             role="button"
             title="Open Export Menu"
-            class="transform-gpu {baseIconClasses}"
+            class="transform-gpu {iconClasses}"
             in:scale={inAnimationParams}
             out:scale={outAnimationParams}
             on:click={() => dispatch('replicateData')}
             on:keyup={dummyFn}
           >
-            <Fa icon={faCloudArrowUp} />
+            <Fa icon={faCloudArrowUp} class={$showHeaderLabels$ ? 'text-sm xl:text-xs' : ''} />
+            {#if $showHeaderLabels$}<span>Export</span>{/if}
           </div>
           {#if $storageSource$ === StorageKey.BROWSER}
             <div
               tabindex="0"
               role="button"
               title="Go to Statistics"
-              class="transform-gpu {baseIconClasses}"
+              class="transform-gpu {iconClasses}"
               in:scale={inAnimationParams}
               out:scale={outAnimationParams}
               on:click={() => dispatch('selectionToStatistics')}
               on:keyup={dummyFn}
             >
-              <Fa icon={faChartLine} />
+              <Fa icon={faChartLine} class={$showHeaderLabels$ ? 'text-sm xl:text-xs' : ''} />
+              {#if $showHeaderLabels$}<span>Statistics</span>{/if}
             </div>
             <div
               tabindex="0"
               role="button"
               title="Delete Statistics for selected Books"
-              class="transform-gpu {baseIconClasses}"
+              class="transform-gpu {iconClasses}"
               in:scale={inAnimationParams}
               out:scale={outAnimationParams}
               on:click={() => dispatch('deleteStatistics')}
               on:keyup={dummyFn}
             >
-              <Fa icon={faCalendarXmark} />
+              <Fa icon={faCalendarXmark} class={$showHeaderLabels$ ? 'text-sm xl:text-xs' : ''} />
+              {#if $showHeaderLabels$}<span>Delete Statistics</span>{/if}
             </div>
           {/if}
           <div
             tabindex="0"
             role="button"
             title="Delete selected Books"
-            class="transform-gpu {baseIconClasses}"
+            class="transform-gpu {iconClasses}"
             in:scale={inAnimationParams}
             out:scale={outAnimationParams}
             on:click={() => dispatch('removeClick')}
             on:keyup={dummyFn}
           >
-            <Fa icon={faTrash} />
+            <Fa icon={faTrash} class={$showHeaderLabels$ ? 'text-sm xl:text-xs' : ''} />
+            {#if $showHeaderLabels$}<span>Delete Book</span>{/if}
           </div>
         {/if}
       </div>

--- a/apps/web/src/lib/components/book-reader/book-reader-header.svelte
+++ b/apps/web/src/lib/components/book-reader/book-reader-header.svelte
@@ -17,10 +17,11 @@
   import {
     baseHeaderClasses,
     baseIconClasses,
+    labelIconClasses,
     nTranslateXHeaderFa,
     translateXHeaderFa
   } from '$lib/css-classes';
-  import { customReadingPointEnabled$, viewMode$ } from '$lib/data/store';
+  import { customReadingPointEnabled$, showHeaderLabels$, viewMode$ } from '$lib/data/store';
   import { ViewMode } from '$lib/data/view-mode';
   import { dummyFn, isMobile$, isOnOldUrl } from '$lib/functions/utils';
   import { createEventDispatcher } from 'svelte';
@@ -93,6 +94,8 @@
     menuItems = items;
   }
 
+  $: iconClasses = $showHeaderLabels$ ? labelIconClasses : baseIconClasses;
+
   function dispatchCustomReadingPointAction(action: any) {
     dispatch(action);
     customReadingPointMenuElm.toggleOpen();
@@ -106,33 +109,39 @@
         tabindex="0"
         role="button"
         title="Open Table of Contents"
-        class={baseIconClasses}
+        class={iconClasses}
         on:click={() => dispatch('tocClick')}
         on:keyup={dummyFn}
       >
-        <Fa icon={faList} />
+        <Fa icon={faList} class={$showHeaderLabels$ ? 'text-sm xl:text-xs' : ''} />
+        {#if $showHeaderLabels$}<span>TOC</span>{/if}
       </div>
     {/if}
     <div
       tabindex="0"
       role="button"
       title="Create Bookmark"
-      class={baseIconClasses}
+      class={iconClasses}
       on:click={() => dispatch('bookmarkClick')}
       on:keyup={dummyFn}
     >
-      <Fa icon={isBookmarkScreen ? fasBookmark : farBookmark} />
+      <Fa
+        icon={isBookmarkScreen ? fasBookmark : farBookmark}
+        class={$showHeaderLabels$ ? 'text-sm xl:text-xs' : ''}
+      />
+      {#if $showHeaderLabels$}<span>Bookmark</span>{/if}
     </div>
     {#if hasBookmarkData}
       <div
         tabindex="0"
         role="button"
         title="Return to Bookmark"
-        class={baseIconClasses}
+        class={iconClasses}
         on:click={() => dispatch('scrollToBookmarkClick')}
         on:keyup={dummyFn}
       >
-        <Fa icon={faRotateLeft} />
+        <Fa icon={faRotateLeft} class={$showHeaderLabels$ ? 'text-sm xl:text-xs' : ''} />
+        {#if $showHeaderLabels$}<span>Return to Bookmark</span>{/if}
       </div>
     {/if}
     {#if $viewMode$ === ViewMode.Continuous && !$isMobile$}
@@ -150,11 +159,12 @@
       tabindex="0"
       role="button"
       title="Complete Book"
-      class={baseIconClasses}
+      class={iconClasses}
       on:click={() => dispatch('completeBook')}
       on:keyup={dummyFn}
     >
-      <Fa icon={faFlag} />
+      <Fa icon={faFlag} class={$showHeaderLabels$ ? 'text-sm xl:text-xs' : ''} />
+      {#if $showHeaderLabels$}<span>Complete Book</span>{/if}
     </div>
     {#if $customReadingPointEnabled$ || $viewMode$ === ViewMode.Paginated}
       <div class="flex">
@@ -164,8 +174,9 @@
           yOffset={0}
           bind:this={customReadingPointMenuElm}
         >
-          <div slot="icon" title="Open Custom Point Actions" class={baseIconClasses}>
-            <Fa icon={faCrosshairs} />
+          <div slot="icon" title="Open Custom Point Actions" class={iconClasses}>
+            <Fa icon={faCrosshairs} class={$showHeaderLabels$ ? 'text-sm xl:text-xs' : ''} />
+            {#if $showHeaderLabels$}<span>Point</span>{/if}
           </div>
           <div class="w-40 bg-gray-700 md:w-32" slot="content">
             {#each customReadingPointMenuItems as actionItem (actionItem.label)}
@@ -188,11 +199,12 @@
         tabindex="0"
         role="button"
         title="Toggle Fullscreen"
-        class={baseIconClasses}
+        class={iconClasses}
         on:click={() => dispatch('fullscreenClick')}
         on:keyup={dummyFn}
       >
-        <Fa icon={faExpand} />
+        <Fa icon={faExpand} class={$showHeaderLabels$ ? 'text-sm xl:text-xs' : ''} />
+        {#if $showHeaderLabels$}<span>Fullscreen</span>{/if}
       </div>
     {/if}
     <MergedHeaderIcon

--- a/apps/web/src/lib/components/merged-header-icon/merged-entries.ts
+++ b/apps/web/src/lib/components/merged-header-icon/merged-entries.ts
@@ -21,7 +21,7 @@ export const mergeEntries = {
   MANAGE: { routeId: '/manage', label: 'Manager', icon: faSignOutAlt, title: 'Go to Book Manager' },
   SETTINGS: {
     routeId: '/settings',
-    label: 'Settings',
+    label: 'Reader Settings',
     icon: faCog,
     title: 'Go to Reader Settings'
   },
@@ -49,13 +49,13 @@ export const mergeEntries = {
     icon: faTriangleExclamation,
     title: 'Old Domain used'
   },
-  BUG_REPORT: { routeId: '', label: 'Bug Report', icon: faBug, title: 'Report an Issue' },
+  BUG_REPORT: { routeId: '', label: 'Issue Report', icon: faBug, title: 'Report an Issue' },
   FOLDER_IMPORT: {
     routeId: '',
-    label: 'Import Folder(s)',
+    label: 'Import Folder',
     icon: faFolderPlus,
     title: 'Import from Folder'
   },
-  FILE_IMPORT: { routeId: '', label: 'Import File(s)', icon: faFileArrowUp, title: 'Import Files' },
+  FILE_IMPORT: { routeId: '', label: 'Import Files', icon: faFileArrowUp, title: 'Import Files' },
   BACKUP_IMPORT: { routeId: '', label: 'Import Backup', icon: faFileZipper, title: 'Import Backup' }
 };

--- a/apps/web/src/lib/components/merged-header-icon/merged-header-icon.svelte
+++ b/apps/web/src/lib/components/merged-header-icon/merged-header-icon.svelte
@@ -5,8 +5,9 @@
   import { page } from '$app/stores';
   import { mergeEntries } from '$lib/components/merged-header-icon/merged-entries';
   import Popover from '$lib/components/popover/popover.svelte';
-  import { baseIconClasses } from '$lib/css-classes';
+  import { baseIconClasses, labelIconClasses } from '$lib/css-classes';
   import { pagePath } from '$lib/data/env';
+  import { showHeaderLabels$ } from '$lib/data/store';
   import { dummyFn } from '$lib/functions/utils';
 
   export let leavePageLink = '';
@@ -38,6 +39,8 @@
     }
   }
 
+  $: iconClasses = $showHeaderLabels$ ? labelIconClasses : baseIconClasses;
+
   if (actionItems.length === 1 && actionItems[0].routeId) {
     leavePageLink = actionItems[0].routeId;
   }
@@ -45,8 +48,9 @@
 
 {#if leavePageLink}
   <a href={leavePageLink}>
-    <div class={baseIconClasses}>
-      <Fa icon={mergeTo.icon} />
+    <div class={iconClasses}>
+      <Fa icon={mergeTo.icon} class={$showHeaderLabels$ ? 'text-sm xl:text-xs' : ''} />
+      {#if $showHeaderLabels$}<span>{mergeTo.label}</span>{/if}
     </div>
   </a>
 {:else}
@@ -56,11 +60,12 @@
         tabindex="0"
         role="button"
         title={actionItem.title}
-        class={baseIconClasses}
+        class={iconClasses}
         on:click={() => handleActionMenuItem(actionItem.label)}
         on:keyup={dummyFn}
       >
-        <Fa icon={actionItem.icon} />
+        <Fa icon={actionItem.icon} class={$showHeaderLabels$ ? 'text-sm xl:text-xs' : ''} />
+        {#if $showHeaderLabels$}<span>{actionItem.label}</span>{/if}
       </div>
     {/each}
   </div>

--- a/apps/web/src/lib/components/settings/settings-content.svelte
+++ b/apps/web/src/lib/components/settings/settings-content.svelte
@@ -186,6 +186,8 @@
 
   export let adjustStatisticsAfterIdleTime: boolean;
 
+  export let showHeaderLabels: boolean;
+
   $: availableThemes = (
     browser
       ? [...Array.from(availableThemesMap.entries()), ...Object.entries($customThemes$)]
@@ -804,6 +806,9 @@
         options={optionsForToggle}
         bind:selectedOptionId={showFooterChapterPercentage}
       />
+    </SettingsItemGroup>
+    <SettingsItemGroup title="Show Header Button Labels">
+      <ButtonToggleGroup options={optionsForToggle} bind:selectedOptionId={showHeaderLabels} />
     </SettingsItemGroup>
     <SettingsItemGroup title="Disable Wheel Navigation">
       <ButtonToggleGroup

--- a/apps/web/src/lib/components/statistics/statistics-header.svelte
+++ b/apps/web/src/lib/components/statistics/statistics-header.svelte
@@ -17,9 +17,9 @@
     statisticsTitleFilterIsOpen$,
     type StatisticsDataSource
   } from '$lib/components/statistics/statistics-types';
-  import { baseHeaderClasses, baseIconClasses, pxScreen } from '$lib/css-classes';
+  import { baseHeaderClasses, baseIconClasses, labelIconClasses, pxScreen } from '$lib/css-classes';
   import { pagePath } from '$lib/data/env';
-  import { lastStatisticsTab$ } from '$lib/data/store';
+  import { lastStatisticsTab$, showHeaderLabels$ } from '$lib/data/store';
   import { dummyFn } from '$lib/functions/utils';
   import Fa from 'svelte-fa';
 
@@ -30,6 +30,8 @@
     { key: 'readingTime', label: 'Reading Time' },
     { key: 'charactersRead', label: 'Characters Read' }
   ];
+
+  $: iconClasses = $showHeaderLabels$ ? labelIconClasses : baseIconClasses;
 
   let copyStatisticsDataPopover: Popover;
 </script>
@@ -44,8 +46,9 @@
           yOffset={0}
           bind:this={copyStatisticsDataPopover}
         >
-          <div title="Copy Data in TMW Log Format" slot="icon" class={baseIconClasses}>
-            <Fa icon={faCopy} />
+          <div title="Copy Data in TMW Log Format" slot="icon" class={iconClasses}>
+            <Fa icon={faCopy} class={$showHeaderLabels$ ? 'text-sm xl:text-xs' : ''} />
+            {#if $showHeaderLabels$}<span>Copy</span>{/if}
           </div>
           <div class="flex flex-col justify-center w-36 bg-gray-700" slot="content">
             {#each copyStatisticsDataItems as copyStatisticsDataItem (copyStatisticsDataItem.key)}
@@ -68,12 +71,13 @@
         title={$lastStatisticsTab$ === StatisticsTab.SUMMARY
           ? 'You are already on the Summary Tab'
           : 'Switch to Summary Tab'}
-        class={baseIconClasses}
+        class={iconClasses}
         class:bg-gray-900={$lastStatisticsTab$ === StatisticsTab.SUMMARY}
         on:click={() => ($lastStatisticsTab$ = StatisticsTab.SUMMARY)}
         on:keyup={dummyFn}
       >
-        <Fa icon={faCalendarDays} />
+        <Fa icon={faCalendarDays} class={$showHeaderLabels$ ? 'text-sm xl:text-xs' : ''} />
+        {#if $showHeaderLabels$}<span>Summary</span>{/if}
       </div>
       <div
         tabindex="0"
@@ -81,18 +85,19 @@
         title={$lastStatisticsTab$ === StatisticsTab.OVERVIEW
           ? 'You are already on the Heatmap Tab'
           : 'Switch to Heatmap Tab'}
-        class={baseIconClasses}
+        class={iconClasses}
         class:bg-gray-900={$lastStatisticsTab$ === StatisticsTab.OVERVIEW}
         on:click={() => ($lastStatisticsTab$ = StatisticsTab.OVERVIEW)}
         on:keyup={dummyFn}
       >
-        <Fa icon={faMap} />
+        <Fa icon={faMap} class={$showHeaderLabels$ ? 'text-sm xl:text-xs' : ''} />
+        {#if $showHeaderLabels$}<span>Heatmap</span>{/if}
       </div>
       <div
         tabindex="0"
         role="button"
         title="Open Title Filter Menu"
-        class={baseIconClasses}
+        class={iconClasses}
         style:cursor={$statisticsTitleFilterEnabled$ ? 'pointer' : 'not-allowed'}
         on:click={() => {
           if (!$statisticsTitleFilterEnabled$) {
@@ -103,33 +108,41 @@
         }}
         on:keyup={dummyFn}
       >
-        <Fa icon={faFilter} />
+        <Fa icon={faFilter} class={$showHeaderLabels$ ? 'text-sm xl:text-xs' : ''} />
+        {#if $showHeaderLabels$}<span>Filter</span>{/if}
       </div>
       <div
         tabindex="0"
         role="button"
         title="Open Statistics Settings"
-        class={baseIconClasses}
+        class={iconClasses}
         on:click={() => (showStatisticsSettings = true)}
         on:keyup={dummyFn}
       >
-        <Fa icon={faSliders} />
+        <Fa icon={faSliders} class={$showHeaderLabels$ ? 'text-sm xl:text-xs' : ''} />
+        {#if $showHeaderLabels$}<span>Statistics Settings</span>{/if}
       </div>
       {#if currentBookId}
-        <svg
+        <div
           tabindex="0"
           role="button"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          class={baseIconClasses}
+          title="Go to Book"
+          class={iconClasses}
           on:click={() => goto(`${pagePath}/b?id=${currentBookId}`)}
           on:keyup={dummyFn}
         >
-          <path
-            class="fill-current"
-            d="M21 5c-1.11-.35-2.33-.5-3.5-.5-1.95 0-4.05.4-5.5 1.5-1.45-1.1-3.55-1.5-5.5-1.5S2.45 4.9 1 6v14.65c0 .25.25.5.5.5.1 0 .15-.05.25-.05C3.1 20.45 5.05 20 6.5 20c1.95 0 4.05.4 5.5 1.5 1.35-.85 3.8-1.5 5.5-1.5 1.65 0 3.35.3 4.75 1.05.1.05.15.05.25.05.25 0 .5-.25.5-.5V6c-.6-.45-1.25-.75-2-1zm0 13.5c-1.1-.35-2.3-.5-3.5-.5-1.7 0-4.15.65-5.5 1.5V8c1.35-.85 3.8-1.5 5.5-1.5 1.2 0 2.4.15 3.5.5v11.5zm-3.5-8c.88 0 1.73.09 2.5.26V9.24c-.79-.15-1.64-.24-2.5-.24-1.7 0-3.24.29-4.5.83v1.66c1.13-.64 2.7-.99 4.5-.99zM13 12.49v1.66c1.13-.64 2.7-.99 4.5-.99.88 0 1.73.09 2.5.26V11.9c-.79-.15-1.64-.24-2.5-.24-1.7 0-3.24.3-4.5.83zm4.5 1.84c-1.7 0-3.24.29-4.5.83v1.66c1.13-.64 2.7-.99 4.5-.99.88 0 1.73.09 2.5.26v-1.52c-.79-.16-1.64-.24-2.5-.24z"
-          />
-        </svg>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            class={$showHeaderLabels$ ? 'h-3.5 w-3.5 xl:h-3 xl:w-3' : 'h-full w-full'}
+          >
+            <path
+              class="fill-current"
+              d="M21 5c-1.11-.35-2.33-.5-3.5-.5-1.95 0-4.05.4-5.5 1.5-1.45-1.1-3.55-1.5-5.5-1.5S2.45 4.9 1 6v14.65c0 .25.25.5.5.5.1 0 .15-.05.25-.05C3.1 20.45 5.05 20 6.5 20c1.95 0 4.05.4 5.5 1.5 1.35-.85 3.8-1.5 5.5-1.5 1.65 0 3.35.3 4.75 1.05.1.05.15.05.25.05.25 0 .5-.25.5-.5V6c-.6-.45-1.25-.75-2-1zm0 13.5c-1.1-.35-2.3-.5-3.5-.5-1.7 0-4.15.65-5.5 1.5V8c1.35-.85 3.8-1.5 5.5-1.5 1.2 0 2.4.15 3.5.5v11.5zm-3.5-8c.88 0 1.73.09 2.5.26V9.24c-.79-.15-1.64-.24-2.5-.24-1.7 0-3.24.29-4.5.83v1.66c1.13-.64 2.7-.99 4.5-.99zM13 12.49v1.66c1.13-.64 2.7-.99 4.5-.99.88 0 1.73.09 2.5.26V11.9c-.79-.15-1.64-.24-2.5-.24-1.7 0-3.24.3-4.5.83zm4.5 1.84c-1.7 0-3.24.29-4.5.83v1.66c1.13-.64 2.7-.99 4.5-.99.88 0 1.73.09 2.5.26v-1.52c-.79-.16-1.64-.24-2.5-.24z"
+            />
+          </svg>
+          {#if $showHeaderLabels$}<span>Book</span>{/if}
+        </div>
       {/if}
       <MergedHeaderIcon items={[mergeEntries.SETTINGS, mergeEntries.MANAGE]} />
     </div>

--- a/apps/web/src/lib/css-classes.ts
+++ b/apps/web/src/lib/css-classes.ts
@@ -16,3 +16,4 @@ export const inputClasses =
 export const buttonClasses =
   'inline-block no-underline font-medium rounded min-w-[32px] sm:min-w-[64px] px-4 leading-9 cursor-pointer text-cyan-900';
 export const baseIconClasses = `flex justify-center select-none items-center h-12 w-12 cursor-pointer text-xl xl:h-10 xl:w-10 xl:text-lg ${pHeaderMat} ${opacityHeaderIcon}`;
+export const labelIconClasses = `flex flex-col items-center justify-center h-12 xl:h-10 min-w-16 px-2 cursor-pointer select-none text-xs xl:text-[10px] ${opacityHeaderIcon}`;

--- a/apps/web/src/lib/data/store.ts
+++ b/apps/web/src/lib/data/store.ts
@@ -510,4 +510,6 @@ export const isOnline$ = writableSubject<boolean>(true);
 
 export const skipKeyDownListener$ = writableSubject<boolean>(false);
 
+export const showHeaderLabels$ = writableBooleanLocalStorageSubject()('showHeaderLabels', false);
+
 export const userFonts$ = writableArrayLocalStorageSubject<UserFont>()('userfonts', []);

--- a/apps/web/src/routes/settings/+page.svelte
+++ b/apps/web/src/routes/settings/+page.svelte
@@ -67,7 +67,8 @@
     viewMode$,
     writingMode$,
     readingGoalsMergeMode$,
-    hideSpoilerImageMode$
+    hideSpoilerImageMode$,
+    showHeaderLabels$
   } from '$lib/data/store';
   import { mergeEntries } from '$lib/components/merged-header-icon/merged-entries';
   import { pagePath } from '$lib/data/env';
@@ -210,6 +211,7 @@
       bind:trackerSkipThresholdAction={$trackerSkipThresholdAction$}
       bind:trackerPopupDetection={$trackerPopupDetection$}
       bind:adjustStatisticsAfterIdleTime={$adjustStatisticsAfterIdleTime$}
+      bind:showHeaderLabels={$showHeaderLabels$}
     />
   </div>
 </div>


### PR DESCRIPTION
Add a showHeaderLabels$ store and "Show Header Button Labels" toggle in Settings > Reader. When enabled, header icon buttons switch from icon-only squares to a flex-column layout with a short descriptive label below each icon.